### PR TITLE
Adds more flexible support for other death plugins.

### DIFF
--- a/src/com/garbagemule/MobArena/MADeathListener.java
+++ b/src/com/garbagemule/MobArena/MADeathListener.java
@@ -36,6 +36,7 @@ public class MADeathListener extends EntityListener
             
             event.getDrops().clear();
             ArenaManager.playerDeath(p);
+            p.getInventory().clear();
         }
         // If monster, remove from monster set
         else if (event.getEntity() instanceof LivingEntity)

--- a/src/com/garbagemule/MobArena/MobArena.java
+++ b/src/com/garbagemule/MobArena/MobArena.java
@@ -67,7 +67,7 @@ public class MobArena extends JavaPlugin
         pm.registerEvent(Event.Type.PLAYER_JOIN,         discListener,     Priority.Normal,  this);
         pm.registerEvent(Event.Type.BLOCK_BREAK,         blockListener,    Priority.Normal,  this);
         pm.registerEvent(Event.Type.BLOCK_PLACE,         blockListener,    Priority.Normal,  this);
-        pm.registerEvent(Event.Type.ENTITY_DEATH,        deathListener,    Priority.Normal,  this);
+        pm.registerEvent(Event.Type.ENTITY_DEATH,        deathListener,    Priority.Lowest,  this);
         pm.registerEvent(Event.Type.ENTITY_EXPLODE,      monsterListener,  Priority.Normal,  this);
         pm.registerEvent(Event.Type.ENTITY_COMBUST,      monsterListener,  Priority.Normal,  this);
         pm.registerEvent(Event.Type.ENTITY_TARGET,       monsterListener,  Priority.Normal,  this);


### PR DESCRIPTION
By changing the priority of events and clearing the inventory when done, this should stop other death plugins from activating when yours does. I didn't get much time to look through the source, so it may need a bit of tweaking to work the way you need it to.
