### PR TITLE
Mob Arena Exploit Fix

### DIFF
--- a/src/com/garbagemule/MobArena/Arena.java
+++ b/src/com/garbagemule/MobArena/Arena.java
@@ -333,6 +333,9 @@ public class Arena
     
     public void playerDeath(final Player p)
     {
+        // teleport them back to the arena location to pop any items out of their hand
+        p.teleport(arenaLoc);
+        
         p.teleport(spectatorLoc);
         p.setFireTicks(0);
         p.setHealth(20);


### PR DESCRIPTION
Fixed exploit where a user could "hold" an item from their inventory to
cause it to drop on the ground in the spectator area.
