### PR TITLE
Moved the stopSpawning() code in endArena() and added an additional check for inventory clearing.

### DIFF
--- a/src/com/garbagemule/MobArena/Arena.java
+++ b/src/com/garbagemule/MobArena/Arena.java
@@ -286,7 +286,7 @@ public class Arena
     public void playerLeave(Player p)
     {
         // Clear class inventory, restore old inventory and fork over rewards.
-        restoreInvAndGiveRewards(p, arenaPlayers.contains(p));
+        restoreInvAndGiveRewards(p, (arenaPlayers.contains(p) || lobbyPlayers.contains(p)));
         
         // Grab the player's entry location, and warp them there.
         Location entry = locations.get(p);


### PR DESCRIPTION
Found the culprit of the bug I was getting (along with some other people), and decided to just make the pull request.  :)  Basically stopSpawning() was being called before the ArenaLog could record the last wave.

Added an extra check for when players join the lobby, pick a class, and then leave before the match starts (inventory wasn't being cleared in this instance).

I did not do a compile and test.
