### PR TITLE
NullPointer log fix

### DIFF
--- a/src/com/garbagemule/MobArena/ArenaLog.java
+++ b/src/com/garbagemule/MobArena/ArenaLog.java
@@ -91,9 +91,9 @@ public class ArenaLog
             // Class
             buffy.append(MAUtils.padRight(entry.getValue(), CLASS + 2, ' '));
             // Wave
-            buffy.append(MAUtils.padLeft(arena.waveMap.remove(p).toString(), WAVE, ' ') + "  ");
+            buffy.append(MAUtils.padLeft(String.valueOf(arena.waveMap.remove(p)), WAVE, ' ') + "  ");
             // Kills
-            buffy.append(MAUtils.padLeft(arena.killMap.remove(p).toString(), KILLS, ' ') + "  ");
+            buffy.append(MAUtils.padLeft(String.valueOf(arena.killMap.remove(p)), KILLS, ' ') + "  ");
             // Rewards
             buffy.append(MAUtils.listToString(arena.rewardMap.get(p), plugin));
             log.add(buffy.toString());


### PR DESCRIPTION
This is a simple fix to prevent the plugin from crashing (and causing cascading issues) on arena end with logging when the maps have a null value in them.
