### PR TITLE
Fix for Sharing after Arena is completed

### DIFF
--- a/src/com/garbagemule/MobArena/MAListener.java
+++ b/src/com/garbagemule/MobArena/MAListener.java
@@ -55,8 +55,10 @@ import com.garbagemule.MobArena.repairable.*;
 
 public class MAListener implements ArenaListener
 {
+    private MobArenaHandler maHandler = new MobArenaHandler();
     private MobArena plugin;
     private Arena arena;
+    
     
     public MAListener(Arena arena, MobArena plugin)
     {
@@ -505,11 +507,21 @@ public class MAListener implements ArenaListener
             event.getItemDrop().remove();
         }
         
-        // Player is in the spectator area
+        // Player is in the spectator list
         else if (arena.specPlayers.contains(p))
         {
-            MAUtils.tellPlayer(p, Msg.LOBBY_DROP_ITEM);
-            event.setCancelled(true);
+            // Player walked out of the spectator area without using "/ma leave"
+            if (!maHandler.inRegion(p.getLocation()))
+            {
+                arena.specPlayers.remove(p);
+                arena.locations.remove(p);
+            }
+            // Player is still in an Arena somewhere
+            else
+            {
+                MAUtils.tellPlayer(p, Msg.LOBBY_DROP_ITEM);
+                event.setCancelled(true);
+            }
         }
     }
 


### PR DESCRIPTION
For when Sharing in Arenas is not allowed, and people wander away from the spectator area without typing "/ma leave" and try to drop items.

This checks their location if they're in the spectating players list, and if they're not in an Arena, remove them from both the spectating players list, and the saved 'joined from' location when they typed "/ma join" or "/ma spectate". If they're in an Arena area still, work as normal.

As an extra note, I have not actually tried this to see if it works, but it seems like it should. I will try it when I have more time.
