### PR TITLE
Update src/com/garbagemule/MobArena/util/ItemParser.java

### DIFF
--- a/src/com/garbagemule/MobArena/util/ItemParser.java
+++ b/src/com/garbagemule/MobArena/util/ItemParser.java
@@ -56,21 +56,21 @@ public class ItemParser
     private static ItemStack withDataAndAmount(String item, String data, String amount)
     {
         Material m = getMaterial(item.toUpperCase());
-        byte     d = getData(data);
+        byte     d = getData(data); //***Needs to be an Integer so that the Potions ID numbers, which are over 255 in some cases, can be included.
         int      a = getAmount(amount);
         
         if (m == null)
             return null;
         
         if (m.getId() == 35)
-            d = (byte) (15-d);
+            d = (byte) (15-d);//Maybe turn the forced byte into a forced Integer. Up 15 to 16472.
         
-        return new ItemStack(m,a,(short)0,d);
+        return new ItemStack(m,a,(short)0,d);//Might need to change the short variable here.
     }
     
     private static Material getMaterial(String item)
     {
-        if (item.matches("[0-9]*"))
+        if (item.matches("[0-9]*"))//Might need to up here ("[0-16471]*")
             return Material.getMaterial(Integer.parseInt(item));
         
         return Material.getMaterial(item.toUpperCase());
@@ -78,13 +78,13 @@ public class ItemParser
     
     private static int getAmount(String amount)
     {
-        if (amount.matches("[1-9][0-9]*"))
+        if (amount.matches("[1-9][0-9]*"))//Might need to up here ("[1-16471][0-16471]*")
             return Integer.parseInt(amount);
         
         return 1;
     }
     
-    private static byte getData(String data)
+    private static byte getData(String data)//Probably will need to include else if code so that it can recognize potions.
     {
         DyeColor dye = null;
         
@@ -92,6 +92,12 @@ public class ItemParser
         {
             dye = DyeColor.getByData(Byte.parseByte(data));
             return dye == null ? 0 : dye.getData();
+        }
+        
+        else if(data.matches("[0-16471]+"))//16,471 is the highest data id assigned to 373:16471 (potions) 
+        {//might be able to stick with dye variable and just up the data amount. Could also move this into else statement.
+            dye = Enums.getEnumFromString(DyeColor.class, data);
+            return dye == null ? 0 : (int) (16472-dye.getData());
         }
         else 
         {


### PR DESCRIPTION
Spots to fix the bug where we cant include potion ID's. Codes for potions are 373:1 - 373:1700ish. The problem I can see is that your third parse to detect the extra part of the item ID has a limited range, which you included to prevent errors I assume, that is too small.

I have pointed out some areas I think should be edited to allow this to work. If you don't want it to throw errors and feel like coding in the individual idem ID's of each potion so you get no errors here is a link to all potion ID's.

http://www.minecraftwiki.net/wiki/Potions#Primary_Potions
