### PR TITLE
Fix conflict with GameMode Inventories.

### DIFF
--- a/src/com/garbagemule/MobArena/ArenaImpl.java
+++ b/src/com/garbagemule/MobArena/ArenaImpl.java
@@ -588,6 +588,7 @@ public class ArenaImpl implements Arena
 
         movePlayerToLobby(p);
         takeFee(p);
+        p.setGameMode(GameMode.SURVIVAL);
         storePlayerData(p, loc);
         removePotionEffects(p);
         MAUtils.sitPets(p);
@@ -597,7 +598,6 @@ public class ArenaImpl implements Arena
             p.setLevel(0);
             p.setExp(0.0f);
         }
-        p.setGameMode(GameMode.SURVIVAL);
         
         arenaPlayerMap.put(p, new ArenaPlayer(p, this, plugin));
 


### PR DESCRIPTION
Moving GameMode switching to before storing the player data means GMI can save the inventory before it is cleared, and prevents eventual inventory loss after MobArena restores it back.

Some more information can be found here: http://dev.bukkit.org/bukkit-plugins/gamemodeinventories/?comment=199