### PR TITLE
Fixes bug when commands are sent by CommandSigns plugin

### DIFF
--- a/src/com/garbagemule/MobArena/ArenaListener.java
+++ b/src/com/garbagemule/MobArena/ArenaListener.java
@@ -3,6 +3,7 @@ package com.garbagemule.MobArena;
 import java.util.*;
 
 import com.garbagemule.MobArena.events.ArenaKillEvent;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -540,7 +541,7 @@ public class ArenaListener
 
         // Make sure to grab the owner of a projectile/pet
         if (damager instanceof Projectile) {
-            damager = ((Projectile) damager).getShooter();
+            damager = (Entity) ((Projectile) damager).getShooter();
         }
         else if (damager instanceof Wolf && arena.hasPet(damager)) {
             damager = (Player) ((Wolf) damager).getOwner();
@@ -626,7 +627,7 @@ public class ArenaListener
             damager = edbe.getDamager();
 
             if (damager instanceof Projectile) {
-                damager = ((Projectile) damager).getShooter();
+                damager = (Entity) ((Projectile) damager).getShooter();
             }
 
             // Repair weapons if necessary

--- a/src/com/garbagemule/MobArena/MobArena.java
+++ b/src/com/garbagemule/MobArena/MobArena.java
@@ -215,7 +215,7 @@ public class MobArena extends JavaPlugin
     
     // Permissions stuff
     public boolean has(Player p, String s) {
-        return p.hasPermission(s);
+        return p.isOp() || p.hasPermission(s);
     }
     
     public boolean has(CommandSender sender, String s) {

--- a/src/com/garbagemule/MobArena/commands/Commands.java
+++ b/src/com/garbagemule/MobArena/commands/Commands.java
@@ -1,7 +1,9 @@
 package com.garbagemule.MobArena.commands;
 
 import java.util.List;
+import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -15,6 +17,14 @@ public class Commands
 {
     public static boolean isPlayer(CommandSender sender) {
         return (sender instanceof Player);
+    }
+    
+    //Sender might be a proxy wrapping a player object. This will get the "real" player object.       
+    public static Player getRealPlayer(CommandSender sender) {
+        Player p    = (Player) sender;
+        UUID uuid = p.getUniqueId();
+        p=Bukkit.getPlayer(uuid);
+        return p;
     }
     
     public static Arena getArenaToJoinOrSpec(ArenaMaster am, Player p, String arg1) {

--- a/src/com/garbagemule/MobArena/commands/setup/ClassChestCommand.java
+++ b/src/com/garbagemule/MobArena/commands/setup/ClassChestCommand.java
@@ -1,5 +1,7 @@
 package com.garbagemule.MobArena.commands.setup;
 
+import java.util.Set;
+
 import com.garbagemule.MobArena.ArenaClass;
 import com.garbagemule.MobArena.Messenger;
 import com.garbagemule.MobArena.Msg;
@@ -8,6 +10,8 @@ import com.garbagemule.MobArena.commands.CommandInfo;
 import com.garbagemule.MobArena.commands.Commands;
 import com.garbagemule.MobArena.framework.ArenaMaster;
 import com.garbagemule.MobArena.util.config.ConfigUtils;
+
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -39,7 +43,7 @@ public class ClassChestCommand implements Command {
         }
 
         Player p = (Player) sender;
-        Block b = p.getTargetBlock(null, 10);
+        Block b = p.getTargetBlock((Set<Material>) null, 10);
 
         switch (b.getType()) {
             case CHEST:

--- a/src/com/garbagemule/MobArena/commands/user/ArenaListCommand.java
+++ b/src/com/garbagemule/MobArena/commands/user/ArenaListCommand.java
@@ -24,7 +24,7 @@ public class ArenaListCommand implements Command
         List<Arena> arenas;
         
         if (Commands.isPlayer(sender)) {
-            Player p = (Player) sender;
+            Player p=Commands.getRealPlayer(sender);
             arenas = am.getPermittedArenas(p); 
         } else {
             arenas = am.getArenas();

--- a/src/com/garbagemule/MobArena/commands/user/JoinCommand.java
+++ b/src/com/garbagemule/MobArena/commands/user/JoinCommand.java
@@ -1,5 +1,8 @@
 package com.garbagemule.MobArena.commands.user;
 
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -24,8 +27,8 @@ public class JoinCommand implements Command
             return true;
         }
         
-        // Cast the sender, grab the argument, if any.
-        Player p    = (Player) sender;
+        // Get the sender (player), grab the argument, if any.
+        Player p=Commands.getRealPlayer(sender);
         String arg1 = (args.length > 0 ? args[0] : null);
         
         // Run some rough sanity checks, and grab the arena to join.

--- a/src/com/garbagemule/MobArena/commands/user/LeaveCommand.java
+++ b/src/com/garbagemule/MobArena/commands/user/LeaveCommand.java
@@ -24,8 +24,8 @@ public class LeaveCommand implements Command
             return true;
         }
         
-        // Cast the sender.
-        Player p = (Player) sender;
+        // Get the sender (player)
+        Player p=Commands.getRealPlayer(sender);
 
         Arena arena = am.getArenaWithPlayer(p);  
         if (arena == null) {

--- a/src/com/garbagemule/MobArena/commands/user/NotReadyCommand.java
+++ b/src/com/garbagemule/MobArena/commands/user/NotReadyCommand.java
@@ -32,7 +32,7 @@ public class NotReadyCommand implements Command
                 return false;
             }
         } else if (Commands.isPlayer(sender)) {
-            Player p = (Player) sender;
+            Player p=Commands.getRealPlayer(sender);
             arena = am.getArenaWithPlayer(p);
             
             if (arena == null) {

--- a/src/com/garbagemule/MobArena/commands/user/PickClassCommand.java
+++ b/src/com/garbagemule/MobArena/commands/user/PickClassCommand.java
@@ -37,7 +37,7 @@ public class PickClassCommand implements Command
         if (args.length != 1) return false;
         
         // Cast the sender
-        Player p = (Player) sender;
+        Player p=Commands.getRealPlayer(sender);
 
         // Make sure the player is in an arena
         Arena arena = am.getArenaWithPlayer(p);

--- a/src/com/garbagemule/MobArena/commands/user/SpecCommand.java
+++ b/src/com/garbagemule/MobArena/commands/user/SpecCommand.java
@@ -24,8 +24,8 @@ public class SpecCommand implements Command
             return false;
         }
         
-        // Cast the sender, grab the argument, if any.
-        Player p    = (Player) sender;
+        // Get the sender (player), grab the argument, if any.
+        Player p=Commands.getRealPlayer(sender);
         String arg1 = (args.length > 0 ? args[0] : null);
         
         // Run some rough sanity checks, and grab the arena to spec.

--- a/src/com/garbagemule/MobArena/metrics/Metrics.java
+++ b/src/com/garbagemule/MobArena/metrics/Metrics.java
@@ -354,7 +354,7 @@ public class Metrics {
         boolean onlineMode = Bukkit.getServer().getOnlineMode(); // TRUE if online mode is enabled
         String pluginVersion = description.getVersion();
         String serverVersion = Bukkit.getVersion();
-        int playersOnline = Bukkit.getServer().getOnlinePlayers().length;
+        int playersOnline = Bukkit.getServer().getOnlinePlayers().size();
  
         // END server software specific section -- all code below does not use any code outside of this class / Java
  


### PR DESCRIPTION
The [CommandSigns](http://dev.bukkit.org/bukkit-plugins/command-signs/) plugin wraps the Player object in a Proxy class, which invokes commands on behalf of a player.

This leads to issues with MobArena when a sign issues "/ma join". MobArena transfers the player to the lobby, but does not recognize that clicks on class signs or iron block actually is done by the same player that joined the game.

