### PR TITLE
Build against Spigot 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.8.7-R0.1-SNAPSHOT</version>
+      <version>1.9.2-R0.1-SNAPSHOT</version>
     </dependency>
 
     <!-- Vault -->


### PR DESCRIPTION
This PR just updates the Maven version for building the plugin to Spigot 1.9.2. I tested with a `mvn clean package` to build a JAR and was able to produce a JAR from it.