### PR TITLE
Fix players being allowed to teleport into arenas after leaving them.

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaListener.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaListener.java
@@ -109,20 +109,20 @@ public class ArenaListener
         this.canShare         = s.getBoolean("share-items-in-arena", true);
         this.autoIgniteTNT    = s.getBoolean("auto-ignite-tnt",      false);
         this.useClassChests   = s.getBoolean("use-class-chests",     false);
-        
+
         this.classLimits = arena.getClassLimitManager();
 
         this.allowMonsters = arena.getWorld().getAllowMonsters();
 
         this.banned = new HashSet<Player>();
     }
-    
+
     void pvpActivate() {
         if (arena.isRunning() && !arena.getPlayersInArena().isEmpty()) {
             pvpEnabled = pvpOn;
         }
     }
-    
+
     void pvpDeactivate() {
         if (pvpOn) pvpEnabled = false;
     }
@@ -138,17 +138,17 @@ public class ArenaListener
 
         // If the arena isn't protected, care
         if (!protect) return;
-        
+
         if (!arena.getRegion().contains(event.getBlock().getLocation()))
             return;
-        
+
         if (!arena.inArena(event.getPlayer())) {
             if (arena.inEditMode())
                 return;
             else
                 event.setCancelled(true);
         }
-        
+
         if (onBlockDestroy(event))
             return;
 
@@ -182,21 +182,21 @@ public class ArenaListener
     private boolean onBlockDestroy(BlockEvent event) {
         if (arena.inEditMode())
             return true;
-        
+
         if (!arena.isRunning())
             return false;
 
         Block b = event.getBlock();
         if (arena.removeBlock(b) || b.getType() == Material.TNT)
             return true;
-        
+
         if (softRestore) {
             if (arena.isProtected())
                 return false;
-            
+
             BlockState state = b.getState();
             Repairable r = null;
-            
+
             if (state instanceof InventoryHolder)
                 r = new RepairableContainer(state);
             else if (state instanceof Sign)
@@ -207,7 +207,7 @@ public class ArenaListener
                 r = new RepairableBlock(state);
 
             arena.addRepairable(r);
-            
+
             if (!softRestoreDrops)
                 b.setTypeId(0);
             return true;
@@ -259,11 +259,11 @@ public class ArenaListener
             arena.addBlock(b.getRelative(0, 1, 0));
         }
     }
-    
+
     private void setPlanter(Metadatable tnt, Player planter) {
         tnt.setMetadata("mobarena-planter", new FixedMetadataValue(plugin, planter));
     }
-    
+
     private Player getPlanter(Metadatable tnt) {
         List<MetadataValue> values = tnt.getMetadata("mobarena-planter");
         for (MetadataValue value : values) {
@@ -474,9 +474,9 @@ public class ArenaListener
     }
 
     /******************************************************
-     * 
+     *
      *                  DEATH LISTENERS
-     * 
+     *
      ******************************************************/
 
     public void onEntityDeath(EntityDeathEvent event) {
@@ -528,11 +528,11 @@ public class ArenaListener
         arena.playerRespawn(p);
         return true;
     }
-    
+
     private void onMountDeath(EntityDeathEvent event) {
         // Shouldn't ever happen
     }
-    
+
     private void onMonsterDeath(EntityDeathEvent event) {
         EntityDamageEvent e1 = event.getEntity().getLastDamageCause();
         EntityDamageByEntityEvent e2 = (e1 instanceof EntityDamageByEntityEvent) ? (EntityDamageByEntityEvent) e1 : null;
@@ -612,9 +612,9 @@ public class ArenaListener
     }
 
     /******************************************************
-     * 
+     *
      *                  DAMAGE LISTENERS
-     * 
+     *
      ******************************************************/
 
     public void onEntityDamage(EntityDamageEvent event) {
@@ -698,7 +698,7 @@ public class ArenaListener
     private void onMountDamage(EntityDamageEvent event, Horse mount, Entity damager) {
         event.setCancelled(true);
     }
-    
+
     private void onMonsterDamage(EntityDamageEvent event, Entity monster, Entity damager) {
         if (damager instanceof Player) {
             Player p = (Player) damager;
@@ -723,7 +723,7 @@ public class ArenaListener
                 event.setCancelled(true);
         }
     }
-    
+
     private void onGolemDamage(EntityDamageEvent event, Entity golem, Entity damager) {
         if (damager instanceof Player) {
             Player p = (Player) damager;
@@ -731,7 +731,7 @@ public class ArenaListener
                 event.setCancelled(true);
                 return;
             }
-            
+
             if (!pvpEnabled) {
                 event.setCancelled(true);
             }
@@ -819,13 +819,13 @@ public class ArenaListener
             }
         }
     }
-    
+
     public void onEntityTeleport(EntityTeleportEvent event) {
         if (region.contains(event.getFrom()) || region.contains(event.getTo())) {
             event.setCancelled(true);
         }
     }
-    
+
     public void onPotionSplash(PotionSplashEvent event) {
         ThrownPotion potion = event.getPotion();
         if (!region.contains(potion.getLocation())) {
@@ -910,18 +910,18 @@ public class ArenaListener
                 event.setCancelled(true);
             }
         }
-        
+
         // If the player is in the lobby, just cancel
         else if (arena.inLobby(p)) {
             Messenger.tell(p, Msg.LOBBY_DROP_ITEM);
             event.setCancelled(true);
         }
-        
+
         // Same if it's a spectator, but...
         else if (arena.inSpec(p)) {
             Messenger.tell(p, Msg.LOBBY_DROP_ITEM);
             event.setCancelled(true);
-            
+
             // If the spectator isn't in the region, force them to leave
             if (!region.contains(p.getLocation())) {
                 Messenger.tell(p, Msg.MISC_MA_LEAVE_REMINDER);
@@ -1012,15 +1012,15 @@ public class ArenaListener
             Messenger.tell(p, Msg.LOBBY_CLASS_PERMISSION);
             return;
         }
-        
+
         ArenaClass oldAC = arena.getArenaPlayer(p).getArenaClass();
         ArenaClass newAC = arena.getClasses().get(className);
-        
+
         // Same class, do nothing.
         if (newAC.equals(oldAC)) {
             return;
         }
-        
+
         // If the new class is full, inform the player.
         if (!classLimits.canPlayerJoinClass(newAC)) {
             Messenger.tell(p, Msg.LOBBY_CLASS_FULL);
@@ -1035,7 +1035,7 @@ public class ArenaListener
                 return;
             }
         }
-        
+
         // Otherwise, leave the old class, and pick the new!
         classLimits.playerLeftClass(oldAC, p);
         classLimits.playerPickedClass(newAC, p);
@@ -1091,7 +1091,7 @@ public class ArenaListener
                             // Then, if no chest was found, check the pillar behind the sign
                             if (blockChest == null) blockChest = findChestBelow(blockBehind, 6);
                         }
-                        
+
                         // If a chest was found, get the contents
                         if (blockChest != null) {
                             InventoryHolder holder = (InventoryHolder) blockChest.getState();
@@ -1125,10 +1125,10 @@ public class ArenaListener
             }
         });
     }
-    
+
     private Block findChestBelow(Block b, int left) {
         if (left < 0) return null;
-        
+
         if (b.getType() == Material.CHEST || b.getType() == Material.TRAPPED_CHEST) {
             return b;
         }
@@ -1164,7 +1164,7 @@ public class ArenaListener
             }
         }, ticks);
     }
-    
+
     public TeleportResponse onPlayerTeleport(PlayerTeleportEvent event) {
         if (!arena.isEnabled() || !region.isSetup() || arena.inEditMode() || allowTeleport) {
             return TeleportResponse.IDGAF;
@@ -1179,7 +1179,7 @@ public class ArenaListener
             if (p.hasPermission("mobarena.admin.teleport")) {
                 return TeleportResponse.ALLOW;
             }
-            
+
             // Players not in the arena are free to warp out.
             if (!arena.inArena(p) && !arena.inLobby(p) && !arena.inSpec(p)) {
                 return TeleportResponse.ALLOW;
@@ -1198,8 +1198,8 @@ public class ArenaListener
             if (p.hasPermission("mobarena.admin.teleport")) {
                 return TeleportResponse.ALLOW;
             }
-            
-            if (region.isWarp(from) || region.isWarp(to) || to.equals(arena.getPlayerEntry(p))) {
+
+            if ((arena.getAllPlayers().contains(event.getPlayer()) && (region.isWarp(from) || region.isWarp(to))) || to.equals(arena.getPlayerEntry(p))) {
                 return TeleportResponse.ALLOW;
             }
 
@@ -1242,10 +1242,10 @@ public class ArenaListener
     public void onPlayerPreLogin(PlayerLoginEvent event) {
         Player p = event.getPlayer();
         if (p == null || !p.isOnline()) return;
-        
+
         Arena arena = plugin.getArenaMaster().getArenaWithPlayer(p);
         if (arena == null) return;
-        
+
         arena.playerLeave(p);
     }
 

--- a/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
+++ b/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
@@ -31,18 +31,18 @@ public class MAGlobalListener implements Listener
 {
     private MobArena plugin;
     private ArenaMaster am;
-    
+
     public MAGlobalListener(MobArena plugin, ArenaMaster am) {
         this.plugin = plugin;
         this.am = am;
     }
-    
+
     ///////////////////////////////////////////////////////////////////////////
     //                                                                       //
     //                            BLOCK EVENTS                               //
     //                                                                       //
     ///////////////////////////////////////////////////////////////////////////
-    
+
     //TODO watch block physics, piston extend, and piston retract events
     @EventHandler(priority = EventPriority.HIGHEST)
     public void blockBreak(BlockBreakEvent event) {
@@ -92,15 +92,15 @@ public class MAGlobalListener implements Listener
         if (!event.getPlayer().hasPermission("mobarena.setup.leaderboards")) {
             return;
         }
-        
+
         if (!event.getLine(0).startsWith("[MA]")) {
             return;
         }
-        
+
         String text = event.getLine(0).substring((4));
         Arena arena;
         Stats stat;
-        
+
         if ((arena = am.getArenaWithName(text)) != null) {
             arena.getEventListener().onSignChange(event);
             setSignLines(event, ChatColor.GREEN + "MobArena", ChatColor.YELLOW + arena.arenaName(), ChatColor.AQUA + "Players", "---------------");
@@ -110,23 +110,23 @@ public class MAGlobalListener implements Listener
             Messenger.tell(event.getPlayer(), "Stat sign created.");
         }
     }
-    
+
     private void setSignLines(SignChangeEvent event, String s1, String s2, String s3, String s4) {
         event.setLine(0, s1);
         event.setLine(1, s2);
         event.setLine(2, s3);
         event.setLine(3, s4);
     }
-    
-    
-    
+
+
+
     ///////////////////////////////////////////////////////////////////////////
     //                                                                       //
     //                           ENTITY EVENTS                               //
     //                                                                       //
     ///////////////////////////////////////////////////////////////////////////
-    
-    
+
+
     @EventHandler(priority = EventPriority.HIGHEST)
     public void creatureSpawn(CreatureSpawnEvent event) {
         for (Arena arena : am.getArenas())
@@ -181,7 +181,7 @@ public class MAGlobalListener implements Listener
         for (Arena arena : am.getArenas())
             arena.getEventListener().onEntityRegainHealth(event);
     }
-    
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void entityFoodLevelChange(FoodLevelChangeEvent event) {
         for (Arena arena : am.getArenas())
@@ -193,30 +193,30 @@ public class MAGlobalListener implements Listener
         for (Arena arena : am.getArenas())
             arena.getEventListener().onEntityTarget(event);
     }
-    
+
     @EventHandler(priority = EventPriority.HIGH)
     public void entityTeleport(EntityTeleportEvent event) {
         for (Arena arena : am.getArenas()) {
             arena.getEventListener().onEntityTeleport(event);
         }
     }
-    
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void potionSplash(PotionSplashEvent event) {
         for (Arena arena : am.getArenas()) {
             arena.getEventListener().onPotionSplash(event);
         }
     }
-    
-    
-    
+
+
+
     ///////////////////////////////////////////////////////////////////////////
     //                                                                       //
     //                           PLAYER EVENTS                               //
     //                                                                       //
     ///////////////////////////////////////////////////////////////////////////
-    
-    
+
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void playerAnimation(PlayerAnimationEvent event) {
         if (!am.isEnabled()) return;
@@ -290,22 +290,22 @@ public class MAGlobalListener implements Listener
                 return;
             }
         }
-        
+
         plugin.restoreInventory(event.getPlayer());
     }
-    
+
     public enum TeleportResponse {
         ALLOW, REJECT, IDGAF
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.HIGH)
     public void playerTeleport(PlayerTeleportEvent event) {
         if (!am.isEnabled()) return;
-        
+
         boolean allow = true;
         for (Arena arena : am.getArenas()) {
             TeleportResponse r = arena.getEventListener().onPlayerTeleport(event);
-            
+
             // If just one arena allows, uncancel and stop.
             switch (r) {
                 case ALLOW:
@@ -317,13 +317,13 @@ public class MAGlobalListener implements Listener
                 default: break;
             }
         }
-        
+
         // Only cancel if at least one arena has rejected the teleport.
         if (!allow) {
             event.setCancelled(true);
         }
     }
-    
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void playerPreLogin(PlayerLoginEvent event) {
         for (Arena arena : am.getArenas()) {
@@ -337,21 +337,21 @@ public class MAGlobalListener implements Listener
             arena.getEventListener().onVehicleExit(event);
         }
     }
-    
-    
-    
+
+
+
     ///////////////////////////////////////////////////////////////////////////
     //                                                                       //
     //                            WORLD EVENTS                               //
     //                                                                       //
     ///////////////////////////////////////////////////////////////////////////
-    
-    
+
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void worldLoadEvent(WorldLoadEvent event) {
         am.loadArenasInWorld(event.getWorld().getName());
     }
-    
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void worldUnloadEvent(WorldUnloadEvent event) {
         am.unloadArenasInWorld(event.getWorld().getName());


### PR DESCRIPTION
Fixes #313 

This doesn't block MobArena from teleporting players, as MA always adds players to the arena _before_ teleporting them.
