### PR TITLE
Don't show arena name in announcements if arena is default

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
@@ -514,9 +514,14 @@ public class ArenaImpl implements Arena
 
         // Announce and clean arena floor, etc.
         if (settings.getBoolean("global-end-announce", false)) {
-            for (Player p : Bukkit.getOnlinePlayers()) {
-                Messenger.tell(p, Msg.ARENA_END_GLOBAL, configName());
-            }
+             for (Player p : Bukkit.getOnlinePlayers()) {
+ -                Messenger.tell(p, Msg.ARENA_END_GLOBAL, configName());
+ +                String arenaName = configName();
+ +                if (arenaName.equalsIgnoreCase("default")) {
+ +                    arenaName = "";
+ +                }
+ +                Messenger.tell(p, Msg.ARENA_END_GLOBAL, arenaName);
+              }
         } else {
             Messenger.announce(this, Msg.ARENA_END);
         }
@@ -581,8 +586,13 @@ public class ArenaImpl implements Arena
         if (settings.getBoolean("global-join-announce", false)) {
             if (lobbyPlayers.isEmpty()) {
                 for (Player q : Bukkit.getOnlinePlayers()) {
-                    Messenger.tell(q, Msg.ARENA_JOIN_GLOBAL, configName());
-                }
+ -                    Messenger.tell(q, Msg.ARENA_JOIN_GLOBAL, configName());
+ +                    String arenaName = configName();
+ +                    if (arenaName.equalsIgnoreCase("default")) {
+ +                        arenaName = "";
+ +                    }
+ +                    Messenger.tell(q, Msg.ARENA_JOIN_GLOBAL, arenaName);
+                  }
             }
         }
 


### PR DESCRIPTION
Just hides the "default" arena name, makes announce messages a bit prettier and easier for players
