### PR TITLE
Add ItemProvider API, to allow other plugins to provide custom items

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/util/ItemParser.java
+++ b/src/main/java/com/garbagemule/MobArena/util/ItemParser.java
@@ -22,6 +22,7 @@ public class ItemParser
 {
     private static final int WOOL_ID = Material.WOOL.getId();
     private static final int DYE_ID  = Material.INK_SACK.getId();
+    private static final List<ItemProvider> providers = new ArrayList<ItemProvider>();
 
     private static final Map<Short, PotionType> POTION_TYPE_MAP = new HashMap<>();
     static {
@@ -38,6 +39,10 @@ public class ItemParser
         POTION_TYPE_MAP.put((short) 8204, PotionType.INSTANT_DAMAGE);
         POTION_TYPE_MAP.put((short) 8205, PotionType.WATER_BREATHING);
         POTION_TYPE_MAP.put((short) 8206, PotionType.INVISIBILITY);
+    }
+
+    public static void registerItemProvider(ItemProvider provider) {
+        providers.add(provider);
     }
     
     public static String parseString(ItemStack... stacks) {
@@ -145,12 +150,16 @@ public class ItemParser
     public static ItemStack parseItem(String item) {
         if (item == null || item.equals(""))
             return null;
-        
+
+        ItemStack result = null;
+        for (ItemProvider provider : providers) {
+            result = provider.getItem(item);
+            if (result != null) return result;
+        }
+
         // Check if the item has enchantments.
         String[] space = item.split(" ");
         String[] parts = (space.length == 2 ? space[0].split(":") : item.split(":"));
-        
-        ItemStack result = null;
         
         switch (parts.length) {
             case 1:

--- a/src/main/java/com/garbagemule/MobArena/util/ItemProvider.java
+++ b/src/main/java/com/garbagemule/MobArena/util/ItemProvider.java
@@ -1,0 +1,18 @@
+package com.garbagemule.MobArena.util;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Integrating plugins may implement this interface and register it with
+ * ItemParser.registerItemProvider to provide custom items.
+ */
+public interface ItemProvider {
+
+    /**
+     * Create an item based on a custom item key.
+     *
+     * @param itemKey The full key string for the item as written in configuration.
+     * @return A new item, or null if this is not a type of item handled by this provider.
+     */
+    ItemStack getItem(String itemKey);
+}


### PR DESCRIPTION
This provides a simple interface and registry for other plugins to be able to add custom items as rewards or class items.

If accepted, I will use this in my Magic plugin to allow players to use wands and other items (guns, etc) in classes, and also receive magic items (skill points, spells, etc) as rewards.

I think this should be extremely low-impact, please let me know if you'd like any changes!

Thanks for your consideration.