### PR TITLE
Ignore cancelled PlayerDropItemEvent events

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
+++ b/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
@@ -280,7 +280,7 @@ public class MAGlobalListener implements Listener
             arena.getEventListener().onPlayerCommandPreprocess(event);
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void playerDropItem(PlayerDropItemEvent event) {
         if (!am.isEnabled()) return;
         for (Arena arena : am.getArenas())


### PR DESCRIPTION
This would be a great change for me, my plugin captures drop events on magic items, but when in an arena this spams a "Sharing is not allowed" message.

I can't see there being any negative side-effects from this, the drop item handler ultimately is there to cancel the event when appropriate, if I'm not mistaken.