### PR TITLE
Addresses Issue #379 - Obsidian Bomb Dropping Block

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/waves/ability/core/ObsidianBomb.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/ability/core/ObsidianBomb.java
@@ -53,9 +53,22 @@ public class ObsidianBomb implements Ability
             public void run() {
                 if (!arena.isRunning())
                     return;
-                
-                world.getBlockAt(loc).breakNaturally();
-                world.createExplosion(loc, 3F);
+                {
+
+                    boolean bombDrop = arena.getSettings ().getBoolean ("allow_bomb_drop");
+
+                    if (bombDrop)
+                    {
+                        world.getBlockAt(loc).breakNaturally();
+                        world.createExplosion(loc, 3F);
+                    }
+                    else
+                    {
+                        world.getBlockAt(loc).setType (Material.AIR);
+                        world.createExplosion(loc, 3F);
+                    }
+                }
+
             }
         }, FUSE);
     }

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -42,3 +42,4 @@ isolated-chat: false
 global-join-announce: false
 global-end-announce: false
 show-death-messages: true
+allow_bomb_drop: true


### PR DESCRIPTION
Added in the ability to toggle the obsidian block dropping from the Obsidian Bomb within the setting.yml. One Idea that someone had to fix this was to implement a toggle able feature from the config.yml to be able to toggle the feature to allow the block to drop from the obsidian bomb if wanted and if not then to not drop the block. Now it would definitely be easier to make it to where the block just doesn't drop at all which who knows may be the better route, but I ended up opting for the toggle able route as seen from the few lines added to the code. If this is not the route to go no problem, but hopefully this will lead to a better fix to this bug. Thanks for considering the code!

~ CreedTheFreak