### PR TITLE
Use display name of items in reward messages, if present.

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
+++ b/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -344,7 +345,17 @@ public class MASpawnThread implements Runnable
                 }
             }
             else {
-                arena.getMessenger().tell(p, Msg.WAVE_REWARD, MAUtils.toCamelCase(reward.getType().toString()) + ":" + reward.getAmount());
+                String itemName = "";
+                ItemMeta meta = reward.getItemMeta();
+                if (meta != null && meta.hasDisplayName()) {
+                    itemName = meta.getDisplayName();
+                } else {
+                    itemName = MAUtils.toCamelCase(reward.getType().toString());
+                }
+                if (reward.getAmount() > 1) {
+                    itemName += ":" + reward.getAmount();
+                }
+                arena.getMessenger().tell(p, Msg.WAVE_REWARD, itemName);
             }
         }
     }


### PR DESCRIPTION
Also don't show amount unless it's greater than one.

This is maybe inconsequential at the moment, but might be a nice change for the future if we find a way to do custom item support.