### PR TITLE
Add support for leave/join signs

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaListener.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaListener.java
@@ -1046,6 +1046,12 @@ public class ArenaListener
     }
 
     private void handleSign(Sign sign, Player p) {
+        // Check if this is a "leave" sign
+        if (ChatColor.stripColor(sign.getLine(1)).equals("Leave")) {
+            arena.playerLeave(p);
+            return;
+        }
+
         // Check if the first line is a class name.
         String className = ChatColor.stripColor(sign.getLine(0)).toLowerCase().replace(" ", "");
 

--- a/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
@@ -228,6 +228,17 @@ public class ArenaMasterImpl implements ArenaMaster
         return null;
     }
 
+    public Arena getArenaWithDisplayName(String arenaName) {
+        return getArenaWithDisplayName(this.arenas, arenaName);
+    }
+
+    public Arena getArenaWithDisplayName(Collection<Arena> arenas, String arenaName) {
+        for (Arena arena : arenas)
+            if (arena.arenaName().equals(arenaName))
+                return arena;
+        return null;
+    }
+
     /*
      * /////////////////////////////////////////////////////////////////////////
      * // // Initialization //

--- a/src/main/java/com/garbagemule/MobArena/framework/ArenaMaster.java
+++ b/src/main/java/com/garbagemule/MobArena/framework/ArenaMaster.java
@@ -84,6 +84,10 @@ public interface ArenaMaster
     Arena getArenaWithName(String configName);
     
     Arena getArenaWithName(Collection<Arena> arenas, String configName);
+
+    Arena getArenaWithDisplayName(String configName);
+
+    Arena getArenaWithDisplayName(Collection<Arena> arenas, String configName);
     
     boolean isAllowed(String command);
     

--- a/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
+++ b/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
@@ -8,6 +8,8 @@ import com.garbagemule.MobArena.util.VersionChecker;
 import com.garbagemule.MobArena.util.inventory.InventoryManager;
 import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -118,10 +120,10 @@ public class MAGlobalListener implements Listener
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void signChange(SignChangeEvent event) {
-        if (!event.getPlayer().hasPermission("mobarena.setup.leaderboards")) {
+        if (!event.getPlayer().hasPermission("mobarena.setup.leaderboards") && !event.getPlayer().hasPermission("mobarena.setup.signs")) {
             return;
         }
-        
+
         if (!event.getLine(0).startsWith("[MA]")) {
             return;
         }
@@ -129,14 +131,29 @@ public class MAGlobalListener implements Listener
         String text = event.getLine(0).substring((4));
         Arena arena;
         Stats stat;
-        
-        if ((arena = am.getArenaWithName(text)) != null) {
-            arena.getEventListener().onSignChange(event);
-            setSignLines(event, ChatColor.GREEN + "MobArena", ChatColor.YELLOW + arena.arenaName(), ChatColor.AQUA + "Players", "---------------");
+
+        if (event.getPlayer().hasPermission("mobarena.setup.signs")) {
+            String signCommand = event.getLine(1);
+            if (signCommand.equalsIgnoreCase("join")) {
+                if ((arena = am.getArenaWithName(text)) != null) {
+                    setSignLines(event, ChatColor.GREEN + "MobArena", ChatColor.YELLOW + arena.arenaName(), ChatColor.BLUE + "Join", "");
+                    return;
+                }
+            } else if (signCommand.equalsIgnoreCase("leave")) {
+                setSignLines(event, ChatColor.GREEN + "MobArena", ChatColor.BLUE + "Leave", "", "");
+                return;
+            }
         }
-        else if ((stat = Stats.getByShortName(text)) != null) {
-            setSignLines(event, ChatColor.GREEN + "", "", ChatColor.AQUA + stat.getFullName(), "---------------");
-            am.getGlobalMessenger().tell(event.getPlayer(), "Stat sign created.");
+
+        if (event.getPlayer().hasPermission("mobarena.setup.leaderboards")) {
+            if ((arena = am.getArenaWithName(text)) != null) {
+                arena.getEventListener().onSignChange(event);
+                setSignLines(event, ChatColor.GREEN + "MobArena", ChatColor.YELLOW + arena.arenaName(), ChatColor.AQUA + "Players", "---------------");
+            }
+            else if ((stat = Stats.getByShortName(text)) != null) {
+                setSignLines(event, ChatColor.GREEN + "", "", ChatColor.AQUA + stat.getFullName(), "---------------");
+                am.getGlobalMessenger().tell(event.getPlayer(), "Stat sign created.");
+            }
         }
     }
     
@@ -291,8 +308,37 @@ public class MAGlobalListener implements Listener
     @EventHandler(priority = EventPriority.HIGHEST)
     public void playerInteract(PlayerInteractEvent event) {
         if (!am.isEnabled()) return;
+
+        // Handle sign clicks while not in lobby
+        if (event.hasBlock() && event.getClickedBlock().getState() instanceof Sign) {
+            Sign sign = (Sign) event.getClickedBlock().getState();
+            if (handleSign(sign, event.getPlayer())) {
+                return;
+            }
+        }
+
         for (Arena arena : am.getArenas())
             arena.getEventListener().onPlayerInteract(event);
+    }
+
+    /**
+     * Handle a sign click from a player.
+     *
+     * @param sign the sign being clicked
+     * @param p the player clicking
+     * @return true if handled, false if not (which should defer to arena processing)
+     */
+    private boolean handleSign(Sign sign, Player p) {
+        // This currently only handles join signs
+        if (sign.getLine(0).equals(ChatColor.GREEN + "MobArena") && sign.getLine(2).equals(ChatColor.BLUE + "Join")) {
+            String arenaName = ChatColor.stripColor(sign.getLine(1));
+            Arena arena = am.getArenaWithDisplayName(arenaName);
+            if (arena != null) {
+                arena.playerJoin(p, p.getLocation());
+                return true;
+            }
+        }
+        return false;
     }
 
     @EventHandler(priority = EventPriority.NORMAL)

--- a/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
+++ b/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
@@ -120,11 +120,12 @@ public class MAGlobalListener implements Listener
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void signChange(SignChangeEvent event) {
-        if (!event.getPlayer().hasPermission("mobarena.setup.leaderboards") && !event.getPlayer().hasPermission("mobarena.setup.signs")) {
+        if (!event.getLine(0).startsWith("[MA]")) {
             return;
         }
 
-        if (!event.getLine(0).startsWith("[MA]")) {
+        if (!event.getPlayer().hasPermission("mobarena.setup.leaderboards") && !event.getPlayer().hasPermission("mobarena.setup.signs")) {
+            event.setCancelled(true);
             return;
         }
         

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -83,6 +83,7 @@ permissions:
             mobarena.setup.classchest: true
             mobarena.setup.classes: true
             mobarena.setup.leaderboards: true
+            mobarena.setup.signs: true
             mobarena.setup.autogenerate: true
             mobarena.setup.autodegenerate: true
     mobarena.setup.config:
@@ -123,6 +124,9 @@ permissions:
         default: false
     mobarena.setup.leaderboards:
         description: Set up leaderboards.
+        default: false
+    mobarena.setup.signs:
+        description: Set up leave/join signs.
         default: false
     mobarena.setup.autogenerate:
         description: Auto-generate an arena.


### PR DESCRIPTION
This adds support for creating signs that players can use to join or leave arenas.

The format is similar to leaderboard signs:

```
[MA]<arena>
Leave/Join
```

There is a new permission for this, "mobarena.setup.signs", which is separate from the leaderboard permission.
