### PR TITLE
Add issue, pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,89 @@
+<!--
+    Thanks for filing a new issue on MobArena! To help us help you, please use
+    this template for filing your bug, feature request, or other topic.
+
+    If you use this template, it helps the developers review your ticket and
+    figure out the problem. If you don't use this template, we may close your
+    issue as not enough information.
+ -->
+
+# Summary
+
+<!--
+    Choose the type of issue you are filing. You can choose one by typing [X] in
+    one of the fields. For example, if a bug report, change the line below to…
+
+    [X] Bug report
+ -->
+
+* This issue is a…
+    * [ ] Bug report
+    * [ ] Feature request
+    * [ ] Other issue
+    * [ ] Question <!-- Please read the wiki first! -->
+* **Describe the issue / feature in 1-2 sentences**: 
+
+
+# Background
+
+<!--
+    This section is very important! First, if you are filing a bug report,
+    DELETE the "Feature request" section. If it's a feature request, DELETE the
+    "Bug report".
+
+    If a bug report, make sure to include all info. This helps us see what
+    you're running and makes it easier to duplicate your problem.
+
+    If a feature request, help us understand your idea. Be descriptive, but also
+    consider any other issues that could happen if it is added. Would it affect
+    other features of MobArena?
+
+    You can get some of this info by typing these commands in-game:
+        /version MobArena: Get your MobArena plugin version
+        /version: Get your Bukkit/Spigot server version
+        /plugins: Get the plugins running on your server
+ -->
+
+### Bug report
+
+* **MobArena version**: 
+* **Server version**: 
+* **Plugins**:
+
+### Feature request 
+
+* **Feature type**:
+    * [ ] Arena configuration
+    * [ ] Classes
+    * [ ] Economy integration
+    * [ ] Leaderboards
+    * [ ] New config settings
+    * [ ] Other (please explain)
+    * [ ] Rewards
+    * [ ] Third-party plugin support
+
+**What does it do?**:
+
+**Does it need new or changed commands? What are they?**:
+
+**Does this feature affect other parts of MobArena?**:
+
+
+# Details
+
+<!--
+    If you have any other details to include, like screenshots, stacktraces¹, or
+    something more detailed, please include it here!
+
+    ¹ Stacktraces are the error messages you see in the console of your server.
+    If you have a long stacktrace, DO NOT PASTE IT HERE! Please use Pastebin and
+    add a link here.
+ -->
+
+* **Stacktrace** (if applicable): 
+
+<!--
+    Phew, all done! Thank you so much for filing a new issue! We'll try to get
+    back to you soon.
+ -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+<!--
+    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
+    time and interest in helping our project!
+
+    Use this template to help us review your change. Not everything is required,
+    depending on your change. Keep or delete what is relevant for your change.
+    Remember that it helps us review if you give more helpful info for us to
+    understand your change.
+ -->
+
+# Summary
+
+<!--
+    Update the checkbox for the type of contribution you are making. To choose
+    an option, add an X to the box. For example, if it's a bug fix, do this:
+
+    * [X] Bug fix
+ -->
+
+* This is a…
+    * [ ] Bug fix
+    * [ ] Feature addition
+    * [ ] Refactoring
+    * [ ] Minor / simple change (like a typo)
+    * [ ] Other
+* **Describe this change in 1-2 sentences**:
+
+
+# Problem
+
+<!-- 
+    Anything that helps us understand why you are making this change goes here.
+    What problem are you trying to fix? What does this change address?
+ -->
+
+* GitHub issue (_optional_):
+
+
+# Solution
+
+<!--
+    The details of your change. Talk about technical details, considerations, or
+    other interesting points. If you have a lot to say, be more detailed in this
+    section.
+ -->
+
+
+# Action
+
+<!--
+    Other than merging your change, do you want / need us to do anything else
+    with your change? This could include reviewing a specific part of your PR.
+ -->
+


### PR DESCRIPTION
# Summary

Add an issue and pull request template for anyone making a contribution or filing a bug against the project

# Analysis

I noticed nobody other than you (@garbagemule) has committed to the project since December, but a lot of people are filing bugs or still using the plugin (since it's awesome). But 59 issues is a lot for a one-man project, and a lot of the issues aren't helpful.

This pull request adds GitHub-friendly issue and pull request templates. Anyone filing a new issue or pull request will see the templates automatically in the text box. I looked through some of the current issues to get an idea of what people are asking or looking at.

# Implementation

As soon as this PR is merged, the templates are live. However, if there's other things that are helpful for you to know, please tell me what those things are and I will add them to the template.

Thanks for all of your work on this over the years. As a long-time user (since ~2012), I hope this makes your life a little easier for reviewing issues or new code contributions. I'll try to help out again if I can find the time!