### PR TITLE
Add TravisCI config to test code against OpenJDK 7, OracleJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+- oraclejdk8
+- openjdk7


### PR DESCRIPTION
# Summary

Adds a simple [TravisCI](https://about.travis-ci.com/) config to test the project against Java 7 + 8 (**requires you to set up Travis for project**)

# Background

There's a few PRs without any feedback or comments. For simple changes (or complex ones, even), a quick test to make sure that the project builds and compiles against Java is helpful. It takes the load off of you, @garbagemule, to test the changes in case something odd breaks.

Ideally, this addition is to help make your life easier.

# Action

Merging this PR first will add the config to the repo, but you need to go to [travis-ci.org](https://travis-ci.org/) to configure it with your project. If you sign in with your GitHub account, it's a point-and-click configuration for the repo, and Travis will start building new commits and pull requests against the project.

If you have other questions, I'm happy to help!