### PR TITLE
Use Thing for class items.

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaClass.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaClass.java
@@ -130,17 +130,6 @@ public class ArenaClass
      */
     public void addItem(Thing thing) {
         if (thing == null) return;
-
-        if (thing instanceof ItemStackThing) {
-            ItemStack stack = ((ItemStackThing)thing).getItem();
-            if (stack.getAmount() > 64) {
-                while (stack.getAmount() > 64) {
-                    items.add(new ItemStackThing(new ItemStack(stack.getType(), 64)));
-                    stack.setAmount(stack.getAmount() - 64);
-                }
-            }
-        }
-
         items.add(thing);
     }
     

--- a/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
@@ -748,7 +748,8 @@ public class ArenaImpl implements Arena
         
         removeClassPermissions(p);
         removePotionEffects(p);
-        
+
+        removeClassThings(p);
         restoreInvAndExp(p);
         if (inLobby(p) || inArena(p)) {
             refund(p);
@@ -1360,6 +1361,12 @@ public class ArenaImpl implements Arena
             }
         }
         p.recalculatePermissions();
+    }
+
+    public void removeClassThings(Player p)
+    {
+        ArenaClass arenaClass = arenaPlayerMap.get(p).getArenaClass();
+        arenaClass.removeThings(p);
     }
 
     @Override

--- a/src/main/java/com/garbagemule/MobArena/things/ItemStackThing.java
+++ b/src/main/java/com/garbagemule/MobArena/things/ItemStackThing.java
@@ -37,4 +37,8 @@ public class ItemStackThing implements Thing {
         }
         return item;
     }
+
+    public ItemStack getItem() {
+        return stack;
+    }
 }

--- a/src/main/java/com/garbagemule/MobArena/things/ThingManager.java
+++ b/src/main/java/com/garbagemule/MobArena/things/ThingManager.java
@@ -45,6 +45,7 @@ public class ThingManager implements ThingParser {
 
     @Override
     public Thing parse(String s) {
+        if (s == null || s.isEmpty()) return null;
         for (ThingParser parser : parsers) {
             Thing thing = parser.parse(s);
             if (thing != null) {
@@ -52,5 +53,23 @@ public class ThingManager implements ThingParser {
             }
         }
         return null;
+    }
+
+    public List<Thing> parseThings(String s) {
+        if (s == null) {
+            return new ArrayList<>(1);
+        }
+
+        String[] items = s.split(",");
+        List<Thing> result = new ArrayList<>(items.length);
+
+        for (String item : items) {
+            Thing thing = parse(item.trim());
+            if (thing != null) {
+                result.add(thing);
+            }
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
This isn't super clean, but it works. 

It will only allow ItemStackThing things to be used for armor slots. The "items" list can be any Things, and the Things are taken away when the player leaves the class. I did not attempt to make a more generic solution, but I think it could be taken further, including collapsing permissions into the Thing system.

# Summary

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Allows Thing instances to be used as class items and armor**:

# Problem

This will allow me to use custom magic items as class items. I extend from ItemStackThing, so this works even for armor- which I know otherwise would seem a little silly to use Thing but then only allow ItemStackThing. However, for my purposes, and for anyone else with a custom item plugin, this makes sense.

