### PR TITLE
Use ItemStack display name when describing an ItemStackThing

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/things/ItemStackThing.java
+++ b/src/main/java/com/garbagemule/MobArena/things/ItemStackThing.java
@@ -28,18 +28,22 @@ public class ItemStackThing implements Thing {
 
     @Override
     public String toString() {
-        ItemMeta itemMeta = stack.getItemMeta();
-        String item = itemMeta == null ? null : itemMeta.getDisplayName();
-        if (item == null || item.isEmpty()) {
-            item = stack.getType()
-                .name()
-                .replace("_", " ")
-                .toLowerCase();
+        String name = getName();
+        int amount = stack.getAmount();
+        if (amount > 1) {
+            return amount + "x " + name;
         }
+        return name;
+    }
 
-        if (stack.getAmount() > 1) {
-            return stack.getAmount() + "x " + item;
+    private String getName() {
+        ItemMeta meta = stack.getItemMeta();
+        if (meta.hasDisplayName()) {
+            return meta.getDisplayName();
         }
-        return item;
+        return stack.getType()
+            .name()
+            .replace("_", " ")
+            .toLowerCase();
     }
 }

--- a/src/main/java/com/garbagemule/MobArena/things/ItemStackThing.java
+++ b/src/main/java/com/garbagemule/MobArena/things/ItemStackThing.java
@@ -2,6 +2,7 @@ package com.garbagemule.MobArena.things;
 
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class ItemStackThing implements Thing {
     private ItemStack stack;
@@ -27,10 +28,14 @@ public class ItemStackThing implements Thing {
 
     @Override
     public String toString() {
-        String item = stack.getType()
-            .name()
-            .replace("_", " ")
-            .toLowerCase();
+        ItemMeta itemMeta = stack.getItemMeta();
+        String item = itemMeta == null ? null : itemMeta.getDisplayName();
+        if (item == null || item.isEmpty()) {
+            item = stack.getType()
+                .name()
+                .replace("_", " ")
+                .toLowerCase();
+        }
 
         if (stack.getAmount() > 1) {
             return stack.getAmount() + "x " + item;


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Provides better descriptions of custom items provided as Thing instances by using the item display name**:

# Problem

Custom items provided by my plugin as Things would show up as hoes instead of their custom display name.

# Solution

Uses a display name in ItemStackThing.toString, if present, otherwise falls back to the same item type pretty-printing.
