### PR TITLE
Stop MobArena interfering with cancelled teleport events

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaListener.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaListener.java
@@ -1214,7 +1214,7 @@ public class ArenaListener
          * transition and are removed from that state as soon as the transition
          * is complete.
          */
-        if (arena.isMoving(p) || p.hasPermission("mobarena.admin.teleport")) {
+        if (arena.isMoving(p)) {
             return TeleportResponse.ALLOW;
         }
 

--- a/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
+++ b/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
@@ -366,7 +366,7 @@ public class MAGlobalListener implements Listener
         }
         
         // Only cancel if at least one arena has rejected the teleport.
-        if (!allow) {
+        if (!allow && !event.getPlayer().hasPermission("mobarena.admin.teleport")) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
The mobarena.admin.teleport permission should stop mobarena from
cancelling teleports for players with that permission. The previous
implementation also uncancelled events which were cancelled by other
plugins. The new implementation moves this check to prevent this
behavior. All MobArena check are done regardless of permission, but if
the player has the override permission, the event is not cancelled.

Fixes #515 (but untested due to build issues with Vault dependency)


This is **UNTESTED** since I am unable to build the project locally - the Vault repository is currently unavailable.