### PR TITLE
Show each player's health under their nametags

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ScoreboardManager.java
+++ b/src/main/java/com/garbagemule/MobArena/ScoreboardManager.java
@@ -29,6 +29,11 @@ public class ScoreboardManager {
         this.arena = arena;
         scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
         scoreboards = new HashMap<>();
+
+        if (arena.getSettings().getBoolean("show-health-under-name", true)) {
+            Objective health = this.scoreboard.registerNewObjective("health", "health", ChatColor.RED + "\u2764");
+            health.setDisplaySlot(DisplaySlot.BELOW_NAME);
+        }
     }
     
     /**

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -40,6 +40,7 @@ boss-health-bar: boss-bar
 display-waves-as-level: false
 display-timer-as-level: false
 use-scoreboards: true
+show-health-under-name: true
 isolated-chat: false
 global-join-announce: false
 global-end-announce: false


### PR DESCRIPTION
# Summary
Adds an option to display the player's health underneath their nametag.

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Adds a visual representation of the player's health underneath their name tag.

# Problem
Currently if an arena has a support class, such as cleric, they have no way of knowing when someone needs healing.

* GitHub issue: #511


# Solution
Display their health underneath their nametag. Doing it this way leaves the other scoreboard features in tact and adds a nice visualization.


# Action
I couldn't determine how to add the new setting to existing configurations, so some insight into how this works would be great. :)