### PR TITLE
Fix fire aspect/flame not working in arenas

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaListener.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaListener.java
@@ -128,6 +128,7 @@ public class ArenaListener
             canShare,
             allowMonsters,
             autoIgniteTNT;
+    private boolean sun = true;
 
     private Set<Player> banned;
 
@@ -841,13 +842,32 @@ public class ArenaListener
         }
     }
 
-    public void onEntityCombust(EntityCombustEvent event) {
-        if (monsters.getMonsters().contains(event.getEntity())) {
-            if (event instanceof EntityCombustByBlockEvent || event instanceof EntityCombustByEntityEvent) {
-                return;
-            }
-            event.setCancelled(true);
-        }
+    public void onEntityCombustByEntity(EntityCombustByEntityEvent event)
+    {
+    	if (monsters.getMonsters().contains(event.getEntity()))
+    	{
+                    sun = false;
+    	}
+    }
+
+    public void onEntityCombustByBlock(EntityCombustByBlockEvent event)
+    {
+    	if (monsters.getMonsters().contains(event.getEntity()))
+    	{
+                    sun = false;
+    	}
+    }
+    
+    public void onEntityCombust(EntityCombustEvent event)
+    {
+    	if (monsters.getMonsters().contains(event.getEntity()))
+    	{
+                if (sun)
+                     {
+                	event.setCancelled(true);
+                      }
+                sun = true;
+    	}
     }
 
     public void onEntityTarget(EntityTargetEvent event) {

--- a/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
+++ b/src/main/java/com/garbagemule/MobArena/listeners/MAGlobalListener.java
@@ -21,6 +21,8 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.entity.EntityCombustByBlockEvent;
+import org.bukkit.event.entity.EntityCombustByEntityEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -177,8 +179,20 @@ public class MAGlobalListener implements Listener
         for (Arena arena : am.getArenas())
             arena.getEventListener().onEntityChangeBlock(event);
     }
+    
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onEntityCombustByEntity(EntityCombustByEntityEvent event) {
+        for (Arena arena : am.getArenas())
+            arena.getEventListener().onEntityCombustByEntity(event);
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onEntityCombustByBlock(EntityCombustByBlockEvent event) {
+        for (Arena arena : am.getArenas())
+            arena.getEventListener().onEntityCombustByBlock(event);
+    }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void entityCombust(EntityCombustEvent event) {
         for (Arena arena : am.getArenas())
             arena.getEventListener().onEntityCombust(event);


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [X] Bug fix
    * [ ] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

it allows fire aspect/flame to work in arenas.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->Currently, the part of the code that remove the daylight combustion for monsters mess with fire aspect and flame enchantments, this pull request fix it.

* GitHub issue : [#519](https://github.com/garbagemule/MobArena/issues/519)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->we check if the combustion is caused by daylight, if it is the case we cancel it.
(kind of what the original code was trying to do, except that it works this time. )
Somehow in the original code, `event instanceof EntityCombustByBlockEvent || event instanceof EntityCombustByEntityEvent` always return false(i cannot explain why, but certainly because event from EntityCombustEvent is different than those from EntityCombustByBlockEvent and EntityCombustByEntityEvent, even if the combust is caused by a block or an entity _-i have not checked this-_) this is the reason of the original code not working properly.

