### PR TITLE
Add player ready state to sign templates

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/signs/LoadsTemplateStore.java
+++ b/src/main/java/com/garbagemule/MobArena/signs/LoadsTemplateStore.java
@@ -72,6 +72,7 @@ class LoadsTemplateStore {
     private boolean hasStateSuffix(String id) {
         return id.endsWith("-idle")
             || id.endsWith("-joining")
+            || id.endsWith("-ready")
             || id.endsWith("-running");
     }
 
@@ -79,12 +80,14 @@ class LoadsTemplateStore {
         String[] base = getLines(yaml, id);
         String[] idle = getLines(yaml, id + "-idle");
         String[] joining = getLines(yaml, id + "-joining");
+        String[] ready = getLines(yaml, id + "-ready");
         String[] running = getLines(yaml, id + "-running");
 
         return new Template.Builder(id)
             .withBase(base)
             .withIdle(idle)
             .withJoining(joining)
+            .withReady(ready)
             .withRunning(running)
             .build();
     }

--- a/src/main/java/com/garbagemule/MobArena/signs/RendersTemplate.java
+++ b/src/main/java/com/garbagemule/MobArena/signs/RendersTemplate.java
@@ -37,6 +37,9 @@ class RendersTemplate {
             return template.running;
         }
         if (arena.getPlayersInLobby().size() > 0) {
+            if (arena.getNonreadyPlayers().size() == 0) {
+                return template.ready;
+            }
             return template.joining;
         }
         return template.idle;

--- a/src/main/java/com/garbagemule/MobArena/signs/Template.java
+++ b/src/main/java/com/garbagemule/MobArena/signs/Template.java
@@ -4,11 +4,13 @@ class Template {
 
     final String[] idle;
     final String[] joining;
+    final String[] ready;
     final String[] running;
 
-    private Template(String[] idle, String[] joining, String[] running) {
+    private Template(String[] idle, String[] joining, String[] ready, String[] running) {
         this.idle = idle;
         this.joining = joining;
+        this.ready = ready;
         this.running = running;
     }
 
@@ -18,6 +20,7 @@ class Template {
         private String[] base;
         private String[] idle;
         private String[] joining;
+        private String[] ready;
         private String[] running;
 
         Builder(String id) {
@@ -39,12 +42,21 @@ class Template {
             return this;
         }
 
+        Builder withReady(String[] lines) {
+            this.ready = lines;
+            return this;
+        }
+
         Builder withRunning(String[] lines) {
             this.running = lines;
             return this;
         }
 
         Template build() {
+            // If the base template has not been defined, there must be
+            // templates for the idle, joining, and running states.
+            // A template for the ready state is optional; If not defined,
+            // it will inherit from the joining template.
             if (base == null) {
                 if (idle == null) {
                     missing("idle");
@@ -62,10 +74,13 @@ class Template {
             if (joining == null) {
                 joining = base;
             }
+            if (ready == null) {
+                ready = joining;
+            }
             if (running == null) {
                 running = base;
             }
-            return new Template(idle, joining, running);
+            return new Template(idle, joining, ready, running);
         }
 
         private void missing(String state) {

--- a/src/test/java/com/garbagemule/MobArena/signs/RendersTemplateTest.java
+++ b/src/test/java/com/garbagemule/MobArena/signs/RendersTemplateTest.java
@@ -96,6 +96,47 @@ public class RendersTemplateTest {
     }
 
     @Test
+    public void readyOverridesLobbyIfPlayersReady() {
+        Player ready = mock(Player.class);
+        Arena arena = mock(Arena.class);
+        when(arena.configName()).thenReturn("castle");
+        when(arena.isRunning()).thenReturn(false);
+        when(arena.getPlayersInLobby()).thenReturn(Collections.singleton(ready));
+        when(arena.getNonreadyPlayers()).thenReturn(Collections.emptyList());
+        when(arena.getReadyPlayersInLobby()).thenReturn(Collections.singleton(ready));
+        String[] readyTemplate = {"we", "are", "all", "ready"};
+        Template template = new Template.Builder("template")
+            .withBase(new String[]{"this", "is", "the", "base"})
+            .withJoining(new String[]{"joining", "template", "is", "here"})
+            .withReady(readyTemplate)
+            .build();
+
+        String[] result = subject.render(template, arena);
+
+        assertThat(result, equalTo(readyTemplate));
+    }
+
+    @Test
+    public void readyPlayersReturnsJoiningIfNotDefined() {
+        Player ready = mock(Player.class);
+        Arena arena = mock(Arena.class);
+        when(arena.configName()).thenReturn("castle");
+        when(arena.isRunning()).thenReturn(false);
+        when(arena.getPlayersInLobby()).thenReturn(Collections.singleton(ready));
+        when(arena.getNonreadyPlayers()).thenReturn(Collections.emptyList());
+        when(arena.getReadyPlayersInLobby()).thenReturn(Collections.singleton(ready));
+        String[] joining = {"we", "in", "da", "lobby"};
+        Template template = new Template.Builder("template")
+            .withBase(new String[]{"this", "is", "the", "base"})
+            .withJoining(joining)
+            .build();
+
+        String[] result = subject.render(template, arena);
+
+        assertThat(result, equalTo(joining));
+    }
+
+    @Test
     public void rendersReadyListEntries() {
         Player ready = mock(Player.class);
         when(ready.getName()).thenReturn("Bobcat00");


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [X] Feature addition

* **Describe this change in 1-2 sentences**:
This adds a new state, _ready_, to allow sign templates to distinguish when all players in the lobby are ready.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

* GitHub issue (_optional_): Fixes #593 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->
This allows additional flexibility in what can done with signs based on the state of the players in the lobby. For example, a sign could display a red 'Not ready' indication along with the names of the not ready players, and a green 'Ready' indication when all the players in the lobby are ready.

Use of the _ready_ state in the template definition is optional. A _ready_ template inherits its values from the _joining_ template definition. If the template definition does not use the _ready_ state, it is backwards-compatible with existing templates.

Overall, the states are _idle_, _joining_, _ready_, and _running_. The state can go "backwards" from _ready_ to _joining_ if another player joins the lobby during the arena start delay.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->
Make sure you check the new test cases.

