### PR TITLE
Make pet names configurable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ These changes will (most likely) be included in the next version.
 ## [Unreleased]
 ### Added
 - New monster variant `angry-bees` can be used to spawn angry bees.
+- Pet names are now per-class configurable via the optional `pet-name` property, which defaults to `<display-name>'s pet` (the `<player-name>` variable is also supported).
 - (API) MobArena's internal command handler now supports registering pre-instantiated subcommand instances. This should make it easier for extensions to avoid the Singleton anti-pattern for command dependencies.
 - (API) MobArena now fires MobArenaPreReloadEvent and MobArenaReloadEvent before and after, respectively, reloading its config-file. This should allow extensions and other plugins to better respond to configuration changes.
 

--- a/src/main/java/com/garbagemule/MobArena/ArenaClass.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaClass.java
@@ -27,6 +27,7 @@ public class ArenaClass
     private boolean unbreakableWeapons, unbreakableArmor;
     private Thing price;
     private Location classchest;
+    private String petName;
 
     /**
      * Create a new, empty arena class with the given name.
@@ -146,6 +147,14 @@ public class ArenaClass
         this.effects = effects;
     }
 
+    public String getPetName() {
+        return this.petName;
+    }
+
+    public void setPetName(String petName) {
+        this.petName = petName;
+    }
+    
     public boolean hasPermission(Player p) {
         String key = "mobarena.classes." + slug;
         if (p.isPermissionSet(key)) {

--- a/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
@@ -393,6 +393,10 @@ public class ArenaMasterImpl implements ArenaMaster
             throw new ConfigError("Failed to parse classchest location for class " + classname + " because: " + e.getMessage());
         }
 
+        // Load pet name
+        String petName = section.getString("pet-name", "<display-name>'s pet");
+        arenaClass.setPetName(petName);
+
         // Finally add the class to the classes map.
         classes.put(arenaClass.getSlug(), arenaClass);
         return arenaClass;

--- a/src/main/java/com/garbagemule/MobArena/SpawnsPets.java
+++ b/src/main/java/com/garbagemule/MobArena/SpawnsPets.java
@@ -1,6 +1,7 @@
 package com.garbagemule.MobArena;
 
 import com.garbagemule.MobArena.framework.Arena;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -42,11 +43,11 @@ public class SpawnsPets {
         }
 
         for (Map.Entry<Material, EntityType> entry : materialToEntity.entrySet()) {
-            spawnPetsFor(player, arena, entry.getKey(), entry.getValue());
+            spawnPetsFor(player, arena, entry.getKey(), entry.getValue(), ac.getPetName());
         }
     }
 
-    private void spawnPetsFor(Player player, Arena arena, Material material, EntityType entity) {
+    private void spawnPetsFor(Player player, Arena arena, Material material, EntityType entity, String petName) {
         PlayerInventory inv = player.getInventory();
 
         int index = inv.first(material);
@@ -57,8 +58,13 @@ public class SpawnsPets {
         int amount = inv.getItem(index).getAmount();
         for (int i = 0; i < amount; i++) {
             Entity pet = arena.getWorld().spawn(player.getLocation(), entity.getEntityClass());
-            pet.setCustomName(player.getDisplayName() + "'s pet");
-            pet.setCustomNameVisible(true);
+            if (!petName.isEmpty()) {
+                String formattedName = ChatColor.translateAlternateColorCodes('&',
+                                       petName.replace("<player-name>", player.getName())
+                                              .replace("<display-name>", player.getDisplayName()));
+                pet.setCustomName(formattedName);
+                pet.setCustomNameVisible(true);
+            }
             if (pet instanceof Tameable) {
                 Tameable tameable = (Tameable) pet;
                 tameable.setTamed(true);

--- a/src/main/java/com/garbagemule/MobArena/SpawnsPets.java
+++ b/src/main/java/com/garbagemule/MobArena/SpawnsPets.java
@@ -59,10 +59,11 @@ public class SpawnsPets {
         for (int i = 0; i < amount; i++) {
             Entity pet = arena.getWorld().spawn(player.getLocation(), entity.getEntityClass());
             if (!petName.isEmpty()) {
-                String formattedName = ChatColor.translateAlternateColorCodes('&',
-                                       petName.replace("<player-name>", player.getName())
-                                              .replace("<display-name>", player.getDisplayName()));
-                pet.setCustomName(formattedName);
+                String resolved = petName
+                    .replace("<player-name>", player.getName())
+                    .replace("<display-name>", player.getDisplayName());
+                String colorized = ChatColor.translateAlternateColorCodes('&', resolved);
+                pet.setCustomName(colorized);
                 pet.setCustomNameVisible(true);
             }
             if (pet instanceof Tameable) {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [X] Feature addition
* **Describe this change in 1-2 sentences**:
This allows pet name tags to be changed via the configuration file, and to include the player's regular name or DisplayName.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->
Pet name tags using DisplayName can be very long.

* GitHub issue (_optional_):
Fixes #595 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->
This change allows server owners to change the name tag to any string, including using color codes, and the variables \<display-name\> and \<player-name\>. It also allows the name tag to be completely disabled by setting it to an empty string.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->
I don't know how to get the new field `pet-name: <display-name>'s pet` into an existing config file. Also, I'm not sure if it needs to be surrounded by single quotes or not.
