### PR TITLE
[Fixes #606] throw config-error if pet-items is null

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
@@ -281,7 +281,8 @@ public class ArenaMasterImpl implements ArenaMaster
 
         ConfigurationSection items = settings.getConfigurationSection("pet-items");
         if(items == null) {
-            throw new ConfigError("Could not find pet-items in config.yml!");
+            makeSection(settings, "pet-items");
+            items = settings.getConfigurationSection("pet-items");
         }
 
         for (String key : items.getKeys(false)) {

--- a/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaMasterImpl.java
@@ -280,6 +280,9 @@ public class ArenaMasterImpl implements ArenaMaster
         spawnsPets.clear();
 
         ConfigurationSection items = settings.getConfigurationSection("pet-items");
+        if(items == null) {
+            throw new ConfigError("Could not find pet-items in config.yml!");
+        }
 
         for (String key : items.getKeys(false)) {
             EntityType entity;


### PR DESCRIPTION
# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Fixes "null" being returned on `/ma reload` if pet-items is null.

# Problem

* GitHub issue (_optional_): #606 

# Solution

Check to see if it's null, if it is, throw the error.

# Action

It should be good, I tested it on my test server.

# Screenshots

"pet-items" missing from config.yml, using jar compiled from master
![image](https://user-images.githubusercontent.com/8278263/77668907-07f94700-6f52-11ea-875a-4a23be7b3930.png)

"pet-items" missing from config.yml, using jar compiled from this PR
![image](https://user-images.githubusercontent.com/8278263/77668941-147d9f80-6f52-11ea-9bd9-6723f0879966.png)

"pet-items" now back in the config.yml, using same jar as prior screenshot (so it doesn't break)
![image](https://user-images.githubusercontent.com/8278263/77669059-442ca780-6f52-11ea-8347-edf2ffd1a9d5.png)
