### PR TITLE
Give iron axe to vindicators by default.

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -188,6 +188,9 @@ public class MACreature
             case "witherskeleton":
                 e.getEquipment().setItemInMainHand(new ItemStack(Material.STONE_SWORD, 1));
                 break;
+            case "vindicator":
+                e.getEquipment().setItemInMainHand(new ItemStack(Material.IRON_AXE, 1));
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
Basically, they just run with nothing right now, making them incredibly weak.

<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [X ] Bug fix

* **Describe this change in 1-2 sentences**:
Just makes vindicators spawn with an iron axe, as they should! 

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

Vindicators spawned with nothing in hand, as opposed to spawning with an iron axe. This pull request aims to fix that tiny issue.

* GitHub issue (_optional_): #686 



