### PR TITLE
Clear only armor from all entities by default, and let minecraft pick the weapon

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,9 +18,11 @@ These changes will (most likely) be included in the next version.
 
 ### Changed
 - MobArena now targets the Minecraft 1.17 version of the Spigot API (but still works on 1.13-1.16). This should make it easier to tackle feature requests and bug reports related to modern Minecraft.
+- Monsters are no longer stripped of the _weapons_ they spawn with naturally, only their _armor_. This should improve forwards compatibility with new weapon-reliant monsters.
 - The regex pattern for the player list command is now less greedy, so it will only match on `/ma players`, `/ma playerlist`, and `/ma player-list`. The previous pattern matched on anything that starts with `player`, which rendered the `/ma player-stats` command in MobArenaStats impossible to invoke.
 
 ### Fixed
+- Pillagers and vindicators no longer spawn without their much-needed weapons.
 - Reward groups with `nothing` in them no longer cause errors when earned/granted.
 
 ## [0.106] - 2021-05-09

--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -30,6 +30,7 @@ public class MACreature {
 
     private static final Map<String,MACreature> map = new HashMap<>();
     private static final List<DyeColor> colors = Arrays.asList(DyeColor.values());
+    private static final ItemStack[] NO_ARMOR = new ItemStack[0];
 
     static {
         registerEntityTypeValues();
@@ -88,8 +89,8 @@ public class MACreature {
 
     public LivingEntity spawn(Arena arena, World world, Location loc) {
         LivingEntity e = (LivingEntity) world.spawnEntity(loc, type);
-        e.getEquipment().clear();
         e.setCanPickupItems(false);
+        e.getEquipment().setArmorContents(NO_ARMOR);
 
         switch (this.name) {
             case "sheep":
@@ -128,10 +129,6 @@ public class MACreature {
             case "magmacubehuge":
                 ((Slime) e).setSize(4);
                 break;
-            case "skeleton":
-            case "stray":
-                e.getEquipment().setItemInMainHand(new ItemStack(Material.BOW, 1));
-                break;
             case "babyzombievillager":
             case "babyzombie":
                 ((Zombie) e).setBaby(true);
@@ -148,9 +145,6 @@ public class MACreature {
                 break;
             case "killerbunny":
                 ((Rabbit) e).setRabbitType(Rabbit.Type.THE_KILLER_BUNNY);
-                break;
-            case "witherskeleton":
-                e.getEquipment().setItemInMainHand(new ItemStack(Material.STONE_SWORD, 1));
                 break;
             default:
                 break;


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ X] Bug fix
    * [ X] Feature addition
* **Describe this change in 1-2 sentences**:


# Problem

Currently, some mobs don't spawn with their right weapons (Pillagers, vindicators, piglins, zombie piglins, and more). We have to add each of them in manually, and we'd need to edit this file every time a new mob with a weapon is added into the game.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

* GitHub issue (_optional_): #686 , #641 , and potentially more in the future. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->
Instead of clearing ALL equipment and then adding in the weapons manually to mobs that need them, this PR aims to _only_ remove armor, and keep the weapons for minecraft to decide. This also solves any equipment issues for any future mobs that might appear. 

