### PR TITLE
Piglin Zombification Fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@ These changes will (most likely) be included in the next version.
 
 ### Fixed
 - Pillagers and vindicators no longer spawn without their much-needed weapons.
+- Piglins, piglin brutes, and hoglins no longer zombify. This fixes a bug where the mobs would despawn due to the zombification process.
 - Reward groups with `nothing` in them no longer cause errors when earned/granted.
 
 ## [0.106] - 2021-05-09

--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -12,14 +12,14 @@ import org.bukkit.entity.Creature;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Hoglin;
+import org.bukkit.entity.PiglinAbstract;
 import org.bukkit.entity.PigZombie;
 import org.bukkit.entity.Rabbit;
 import org.bukkit.entity.Sheep;
 import org.bukkit.entity.Slime;
 import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Zombie;
-import org.bukkit.entity.Hoglin;
-import org.bukkit.entity.PiglinAbstract;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 

--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -7,17 +7,7 @@ import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.entity.Bee;
-import org.bukkit.entity.Creature;
-import org.bukkit.entity.Creeper;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.PigZombie;
-import org.bukkit.entity.Rabbit;
-import org.bukkit.entity.Sheep;
-import org.bukkit.entity.Slime;
-import org.bukkit.entity.Wolf;
-import org.bukkit.entity.Zombie;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
@@ -152,6 +142,12 @@ public class MACreature {
             case "witherskeleton":
                 e.getEquipment().setItemInMainHand(new ItemStack(Material.STONE_SWORD, 1));
                 break;
+            case "piglin":
+                ((Piglin) e).setImmuneToZombification(true);
+            case "piglinbrute":
+                ((PiglinBrute) e).setImmuneToZombification(true);
+            case "hoglin":
+                ((Hoglin) e).setImmuneToZombification(true);
             default:
                 break;
         }

--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -154,6 +154,7 @@ public class MACreature {
                 break;
             case "hoglin":
                 ((Hoglin) e).setImmuneToZombification(true);
+                break;
             default:
                 break;
         }

--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -7,7 +7,19 @@ import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Bee;
+import org.bukkit.entity.Creature;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.PigZombie;
+import org.bukkit.entity.Rabbit;
+import org.bukkit.entity.Sheep;
+import org.bukkit.entity.Slime;
+import org.bukkit.entity.Wolf;
+import org.bukkit.entity.Zombie;
+import org.bukkit.entity.Hoglin;
+import org.bukkit.entity.PiglinAbstract;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
@@ -143,9 +155,8 @@ public class MACreature {
                 e.getEquipment().setItemInMainHand(new ItemStack(Material.STONE_SWORD, 1));
                 break;
             case "piglin":
-                ((Piglin) e).setImmuneToZombification(true);
             case "piglinbrute":
-                ((PiglinBrute) e).setImmuneToZombification(true);
+                ((PiglinAbstract) e).setImmuneToZombification(true);
             case "hoglin":
                 ((Hoglin) e).setImmuneToZombification(true);
             default:

--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -151,6 +151,7 @@ public class MACreature {
             case "piglin":
             case "piglinbrute":
                 ((PiglinAbstract) e).setImmuneToZombification(true);
+                break;
             case "hoglin":
                 ((Hoglin) e).setImmuneToZombification(true);
             default:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ X] Bug fix
* **Describe this change in 1-2 sentences**:
This PR aims to fix piglin type mobs zombifiying mid-wave, therefore vanishing and serving no purpose. 
# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

To keep it short, as it currently stands, Piglins/Piglin Brutes/Hoglins vanish mid-wave. This is because minecraft attempts to turn them into their 'zombified' counterpart by despawning them, and then spawning the pigzombie version of them. MobArena prevents the respawn to happen, and thus, they just randomly despawn. 
* GitHub issue (_optional_): #684 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->
By using setImmuneToZombification, we can just tell minecraft to _stop_ trying to zombify them. It's quite a simple fix, but it works perfectly fine
