### PR TITLE
Fix some Ageable Entities spawning as baby versions sometimes, and add more baby variants 

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MACreature.java
@@ -5,20 +5,20 @@ import com.garbagemule.MobArena.framework.Arena;
 import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Bee;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Hoglin;
-import org.bukkit.entity.PiglinAbstract;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.PigZombie;
+import org.bukkit.entity.PiglinAbstract;
 import org.bukkit.entity.Rabbit;
 import org.bukkit.entity.Sheep;
 import org.bukkit.entity.Slime;
 import org.bukkit.entity.Wolf;
+import org.bukkit.entity.Zoglin;
 import org.bukkit.entity.Zombie;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -131,29 +131,50 @@ public class MACreature {
             case "magmacubehuge":
                 ((Slime) e).setSize(4);
                 break;
+            case "babydrowned":
+            case "babyhusk":
             case "babyzombievillager":
             case "babyzombie":
                 ((Zombie) e).setBaby(true);
+                break;
+            case "babyhoglin":
+                ((Hoglin) e).setImmuneToZombification(true);
+                ((Hoglin) e).setBaby();
+                break;
+            case "babypiglin":
+                ((PiglinAbstract)e).setBaby();
+                ((PiglinAbstract) e).setImmuneToZombification(true);
                 break;
             case "babypigman":
             case "babyzombifiedpiglin":
                 ((Zombie) e).setBaby(true);
                 ((PigZombie) e).setAngry(true);
                 break;
+            case "babyzoglin":
+                ((Zoglin) e).setBaby();
+                break;
             case "pigzombie":
             case "zombiepigman":
             case "zombifiedpiglin":
                 ((PigZombie) e).setAngry(true);
+                ((PigZombie) e).setBaby(false);
                 break;
+            case "husk":
+            case "drowned":
+            case "zombievillager":
+            case "zombie":
+                ((Zombie) e).setBaby(false);
             case "killerbunny":
                 ((Rabbit) e).setRabbitType(Rabbit.Type.THE_KILLER_BUNNY);
                 break;
             case "piglin":
             case "piglinbrute":
                 ((PiglinAbstract) e).setImmuneToZombification(true);
+                ((PiglinAbstract) e).setAdult();
                 break;
             case "hoglin":
                 ((Hoglin) e).setImmuneToZombification(true);
+                ((Hoglin) e).setAdult();
                 break;
             default:
                 break;
@@ -241,6 +262,12 @@ public class MACreature {
         //
         put("angrybee", "angrybees", "BEE", null);
         put("angrywolf", "angrywolves", "WOLF");
+        put("babypiglin", "babypiglins", "PIGLIN");
+        put("babyzombifiedpiglin", "babyzombifiedpiglins", "ZOMBIFIED_PIGLIN");
+        put("babyhoglin", "babyhoglins", "HOGLIN");
+        put("babyzoglin", "babyzoglins", "ZOGLIN");
+        put("babyhusk", "babyhusks", "HUSK");
+        put("babydrowned", "babydrowneds", "DROWNED");
         put("babyzombie", "babyzombies", "ZOMBIE");
         put("babyzombievillager", "babyzombievillagers", "ZOMBIE_VILLAGER");
         put("killerbunny", "killerbunnies", "RABBIT");


### PR DESCRIPTION
Sometimes, adult entities used to spawn as babies. Not only that, but some of the baby variants were missing. This commit adds any missing variants and fixes the issue with adults turning to babies randomly, by making sure to set any

<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ X] Bug fix
    * [ X] Feature addition
* **Describe this change in 1-2 sentences**:
Sets any ageable entities to adults by default, and only sets them to babies when specified. Also includes missing baby types from #689 

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->
As described in issue #687, entities with ageable variants sometimes spawn as babies. And not only that, some of said baby variants are missing from the MACreature file, as described in issue #689. This pull request makes sure any entities that are not supposed to be babies are set as adults, and adds more baby types. 
* GitHub issue (_optional_): #687 and #689 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->
Simply put, just turn any regular entities to adults, and only turn them into babies when specified. I would've made an if statement by checking `e instanceof ageable` then turning it into an adult if true, just to save a bit of branches. Sadly, that would break any old versions running Mobarena, since they don't have the ageable option. 


