### PR TITLE
Clear-Condition Tweaks | Adding clear-leeway

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ These changes will (most likely) be included in the next version.
 - Husks, drowned, piglins, hoglins, and zoglins can now be spawned in their baby versions using the `baby` prefix seen on other monster types (e.g. `baby-zombie`).
 - Pet names are now per-class configurable via the optional `pet-name` property, which defaults to `<display-name>'s pet` (the `<player-name>` variable is also supported).
 - New per-arena setting `auto-leave-on-end` can be used to automatically "kick" spectators when the current session ends.
+- New per-arena setting `clear-wave-leeway` allows for tweaking the number of mobs allowed to be alive before the next wave spawns. The setting affects `clear-wave-before-next`, `clear-wave-before-boss`, and the final wave check, and it defaults to 0.
 - Added boss abilities `disorient-all`, `fetch-all`, `pull-all`, and `throw-all`. These abilities work like their target-specific and distance-based counterparts, but affect all players in the arena.
 - (API) MobArena's internal command handler now supports registering pre-instantiated subcommand instances. This should make it easier for extensions to avoid the Singleton anti-pattern for command dependencies.
 - (API) MobArena now fires MobArenaPreReloadEvent and MobArenaReloadEvent before and after, respectively, reloading its config-file. This should allow extensions and other plugins to better respond to configuration changes.

--- a/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
+++ b/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
@@ -40,8 +40,9 @@ public class MASpawnThread implements Runnable
     private MonsterManager monsterManager;
     private CreatesHealthBar createsHealthBar;
 
-    private int playerCount, monsterLimit, waveLeeway;
+    private int playerCount, monsterLimit;
     private boolean waveClear, bossClear, preBossClear, wavesAsLevel;
+    private int waveLeeway;
     private int waveInterval;
     private int nextWaveDelay;
 
@@ -73,10 +74,10 @@ public class MASpawnThread implements Runnable
         waveManager.reset();
         playerCount = arena.getPlayersInArena().size();
         monsterLimit = arena.getSettings().getInt("monster-limit", 100);
-        waveLeeway = arena.getSettings().getInt("clear-wave-leeway", 0);
         waveClear = arena.getSettings().getBoolean("clear-wave-before-next", false);
         bossClear = arena.getSettings().getBoolean("clear-boss-before-next", false);
         preBossClear = arena.getSettings().getBoolean("clear-wave-before-boss", false);
+        waveLeeway = arena.getSettings().getInt("clear-wave-leeway", 0);
         wavesAsLevel = arena.getSettings().getBoolean("display-waves-as-level", false);
         waveInterval = arena.getSettings().getInt("wave-interval", 3);
         nextWaveDelay = arena.getSettings().getInt("next-wave-delay", 0);

--- a/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
+++ b/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
@@ -41,7 +41,7 @@ public class MASpawnThread implements Runnable
     private CreatesHealthBar createsHealthBar;
 
     private int playerCount, monsterLimit, waveLeeway;
-    private boolean waveClear, bossClear, preBossClear, wavesAsLevel, endAfterBossKill;
+    private boolean waveClear, bossClear, preBossClear, wavesAsLevel;
     private int waveInterval;
     private int nextWaveDelay;
 
@@ -77,7 +77,6 @@ public class MASpawnThread implements Runnable
         waveClear = arena.getSettings().getBoolean("clear-wave-before-next", false);
         bossClear = arena.getSettings().getBoolean("clear-boss-before-next", false);
         preBossClear = arena.getSettings().getBoolean("clear-wave-before-boss", false);
-        endAfterBossKill = arena.getSettings().getBoolean("end-after-final-boss-kill", false);
         wavesAsLevel = arena.getSettings().getBoolean("display-waves-as-level", false);
         waveInterval = arena.getSettings().getInt("wave-interval", 3);
         nextWaveDelay = arena.getSettings().getInt("next-wave-delay", 0);
@@ -321,12 +320,7 @@ public class MASpawnThread implements Runnable
         }
 
         // Check for final wave
-        if (!endAfterBossKill && !monsterManager.getMonsters().isEmpty() && waveManager.getWaveNumber() == waveManager.getFinalWave()) {
-            return false;
-        }
-
-        // Check for boss clear final wave
-        if (endAfterBossKill && !monsterManager.getBossMonsters().isEmpty() && waveManager.getWaveNumber() == waveManager.getFinalWave()) {
+        if (monsterManager.getMonsters().size() > waveLeeway && waveManager.getWaveNumber() == waveManager.getFinalWave()) {
             return false;
         }
 

--- a/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
+++ b/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
@@ -42,7 +42,7 @@ public class MASpawnThread implements Runnable
 
     private int playerCount, monsterLimit;
     private boolean waveClear, bossClear, preBossClear, wavesAsLevel;
-    private int waveLeeway;
+    private int clearLeeway;
     private int waveInterval;
     private int nextWaveDelay;
 
@@ -77,7 +77,7 @@ public class MASpawnThread implements Runnable
         waveClear = arena.getSettings().getBoolean("clear-wave-before-next", false);
         bossClear = arena.getSettings().getBoolean("clear-boss-before-next", false);
         preBossClear = arena.getSettings().getBoolean("clear-wave-before-boss", false);
-        waveLeeway = arena.getSettings().getInt("clear-wave-leeway", 0);
+        clearLeeway = arena.getSettings().getInt("clear-wave-leeway", 0);
         wavesAsLevel = arena.getSettings().getBoolean("display-waves-as-level", false);
         waveInterval = arena.getSettings().getInt("wave-interval", 3);
         nextWaveDelay = arena.getSettings().getInt("next-wave-delay", 0);
@@ -311,17 +311,17 @@ public class MASpawnThread implements Runnable
         }
 
         // Check for wave clear
-        if (waveClear && monsterManager.getMonsters().size() > waveLeeway) {
+        if (waveClear && monsterManager.getMonsters().size() > clearLeeway) {
             return false;
         }
 
         // Check for pre boss clear
-        if (preBossClear && waveManager.getNext().getType() == WaveType.BOSS && monsterManager.getMonsters().size() > waveLeeway) {
+        if (preBossClear && waveManager.getNext().getType() == WaveType.BOSS && monsterManager.getMonsters().size() > clearLeeway) {
             return false;
         }
 
         // Check for final wave
-        if (monsterManager.getMonsters().size() > waveLeeway && waveManager.getWaveNumber() == waveManager.getFinalWave()) {
+        if (monsterManager.getMonsters().size() > clearLeeway && waveManager.getWaveNumber() == waveManager.getFinalWave()) {
             return false;
         }
 

--- a/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
+++ b/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
@@ -40,7 +40,7 @@ public class MASpawnThread implements Runnable
     private MonsterManager monsterManager;
     private CreatesHealthBar createsHealthBar;
 
-    private int playerCount, monsterLimit;
+    private int playerCount, monsterLimit, waveThreshold;
     private boolean waveClear, bossClear, preBossClear, wavesAsLevel;
     private int waveInterval;
     private int nextWaveDelay;
@@ -308,8 +308,8 @@ public class MASpawnThread implements Runnable
             return false;
         }
 
-        // Check for wave and pre boss clear
-        if (waveClear && !monsterManager.getMonsters().isEmpty()) {
+        // Check for wave clear and if monsters alive is less than or equal to the defined option
+        if (waveClear && monsterManager.getMonsters().size() > waveThreshold) {
             return false;
         }
 

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -25,6 +25,7 @@ first-wave-delay: 5
 next-wave-delay: 0
 wave-interval: 15
 final-wave: 0
+wave-threshold: 0
 monster-limit: 100
 monster-exp: false
 keep-exp: false

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -7,6 +7,7 @@ default-class: ''
 clear-wave-before-next: false
 clear-boss-before-next: false
 clear-wave-before-boss: false
+end-after-final-boss-kill: false
 soft-restore: false
 soft-restore-drops: false
 require-empty-inv-join: false
@@ -25,8 +26,8 @@ first-wave-delay: 5
 next-wave-delay: 0
 wave-interval: 15
 final-wave: 0
-wave-threshold: 0
 monster-limit: 100
+clear-wave-leeway: 0
 monster-exp: false
 keep-exp: false
 food-regen: false

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -7,6 +7,7 @@ default-class: ''
 clear-wave-before-next: false
 clear-boss-before-next: false
 clear-wave-before-boss: false
+clear-wave-leeway: 0
 soft-restore: false
 soft-restore-drops: false
 require-empty-inv-join: false
@@ -26,7 +27,6 @@ next-wave-delay: 0
 wave-interval: 15
 final-wave: 0
 monster-limit: 100
-clear-wave-leeway: 0
 monster-exp: false
 keep-exp: false
 food-regen: false

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -7,7 +7,6 @@ default-class: ''
 clear-wave-before-next: false
 clear-boss-before-next: false
 clear-wave-before-boss: false
-end-after-final-boss-kill: false
 soft-restore: false
 soft-restore-drops: false
 require-empty-inv-join: false


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Prevent the next wave from occuring if there are more mobs alive than the defined amount, if clear-wave-before-next is true

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->
Allows users to define at what point to trigger the next wave, preventing players from spending ages to find the last baby zombie hiding somewhere in the corner.

* GitHub issue: #706


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->
Instead of checking if there are no more monsters alive, check if there are less or the same amount of mobs alive as the wave-threshold.


