### PR TITLE
Reset player fall-distance on select teleports.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@ These changes will (most likely) be included in the next version.
 - Arena Signs now correctly update for arenas that don't have `kebab-case` names in the config-file. 
 - Block explosion events cancelled by other plugins now remain cancelled unless MobArena specifically uncancels them for an arena.
 - Flaming arrows now ignite TNT blocks in the arena.
+- Players no longer take fall damage when they leave (or get removed from) an arena while falling.
 
 ## [0.106] - 2021-05-09
 ### Added

--- a/src/main/java/com/garbagemule/MobArena/steps/MovePlayerStep.java
+++ b/src/main/java/com/garbagemule/MobArena/steps/MovePlayerStep.java
@@ -2,10 +2,13 @@ package com.garbagemule.MobArena.steps;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 
 import java.util.function.Supplier;
 
 abstract class MovePlayerStep extends PlayerStep {
+    private static final Vector NULL_VECTOR = new Vector(0, 0, 0);
+
     private final Supplier<Location> destination;
 
     private Location location;
@@ -19,11 +22,13 @@ abstract class MovePlayerStep extends PlayerStep {
     public void run() {
         location = player.getLocation();
 
+        player.setVelocity(NULL_VECTOR);
         player.teleport(destination.get());
     }
 
     @Override
     public void undo() {
+        player.setVelocity(NULL_VECTOR);
         player.teleport(location);
     }
 }

--- a/src/main/java/com/garbagemule/MobArena/steps/MovePlayerStep.java
+++ b/src/main/java/com/garbagemule/MobArena/steps/MovePlayerStep.java
@@ -7,8 +7,6 @@ import org.bukkit.util.Vector;
 import java.util.function.Supplier;
 
 abstract class MovePlayerStep extends PlayerStep {
-    private static final Vector NULL_VECTOR = new Vector(0, 0, 0);
-
     private final Supplier<Location> destination;
 
     private Location location;
@@ -22,13 +20,13 @@ abstract class MovePlayerStep extends PlayerStep {
     public void run() {
         location = player.getLocation();
 
-        player.setVelocity(NULL_VECTOR);
+        player.setFallDistance(0.0F);
         player.teleport(destination.get());
     }
 
     @Override
     public void undo() {
-        player.setVelocity(NULL_VECTOR);
+        player.setFallDistance(0.0F);
         player.teleport(location);
     }
 }


### PR DESCRIPTION
Sets the player fall-distance to zero before performing a player
teleport during "move player" steps. This should cancel out any already
calculated, added fall-distance that might result in unintentional
fall damage.

Fixes #698

<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [X] Bug fix
    * [ ] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

* GitHub issue (_optional_): #698


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->

Your attempt with resetting the velocity was a good first step, but not sufficient.
After a quick google-search, I found some other examples that also resetted the fall-distance.
(Like https://www.tabnine.com/web/assistant/code/rs/5c65732f1095a50001513a9a#L1830)

The combination of resetting both the velocity and fall-distance seems to work.
No single death after 20 attempts.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->

Feel free to squash my commit with your previous one. I guess there is no need
for keeping both commits/commit-messages.
