### PR TITLE
Add configuration option for monster to always follow a player position.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ These changes will (most likely) be included in the next version.
 - Husks, drowned, piglins, hoglins, and zoglins can now be spawned in their baby versions using the `baby` prefix seen on other monster types (e.g. `baby-zombie`).
 - Pet names are now per-class configurable via the optional `pet-name` property, which defaults to `<display-name>'s pet` (the `<player-name>` variable is also supported).
 - New per-arena setting `auto-leave-on-end` can be used to automatically "kick" spectators when the current session ends.
+- New per-arena setting `monster-tracks-player` can be used to make monsters always follow a player. If monsters lose their target and can not find a closer one, they will follow their last known target. If their last known target dies or leaves the arena, they will follow a random target.
 - Added boss abilities `disorient-all`, `fetch-all`, `pull-all`, and `throw-all`. These abilities work like their target-specific and distance-based counterparts, but affect all players in the arena.
 - (API) MobArena's internal command handler now supports registering pre-instantiated subcommand instances. This should make it easier for extensions to avoid the Singleton anti-pattern for command dependencies.
 - (API) MobArena now fires MobArenaPreReloadEvent and MobArenaReloadEvent before and after, respectively, reloading its config-file. This should allow extensions and other plugins to better respond to configuration changes.

--- a/src/main/java/com/garbagemule/MobArena/MAUtils.java
+++ b/src/main/java/com/garbagemule/MobArena/MAUtils.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 public class MAUtils
@@ -101,6 +102,26 @@ public class MAUtils
                 current = dist;
                 result = p;
             }
+        }
+        return result;
+    }
+
+    public static Player getClosestPlayer(MobArena plugin, Entity e, Arena arena, Player target) {
+        // Try getting closest player to monster by running original method
+        Player result = getClosestPlayer(plugin, e, arena);
+        Player fallBack = null;
+
+        if (result == null) {
+            // If closest player returns null, return last known player target
+            if (target != null && arena.getPlayersInArena().contains(target)) {
+                return target;
+            }
+            // Use a random arena player as a fallback if lastKnownPlayer dies or leaves
+            List<Player> players = new ArrayList<>(arena.getPlayersInArena());
+            Random rand = new Random();
+            int randomPlayer = rand.nextInt(players.size());
+            fallBack = players.get(randomPlayer);
+            return fallBack;
         }
         return result;
     }

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -13,6 +13,7 @@ require-empty-inv-join: false
 require-empty-inv-spec: false
 pvp-enabled: false
 monster-infight: false
+monster-tracks-player: false
 allow-teleporting: false
 spectate-on-death: true
 auto-leave-on-end: false


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
*  Adds a new per-arena setting `monster-tracks-player` that forces monsters to always follow a known player location.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

A monster loses a target if it moves outside a 16 block radius (default). Currently, MobArena runs a _getClosestPlayer_ method that tries making the monster find a new closest target by comparing the distances between itself and the list of alive players in the arena. However, sometimes this check returns `null`. This happens most often if the closest player or all players are behind multiple walls or different vertical heights. When this check returns `null` the monster starts to wander. 

* See https://github.com/garbagemule/MobArena/issues/412#issuecomment-350590920 for details.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->

Added a HashMap __lastKnownPlayerTargets__ to store monster entity IDs and a player target. If the boolean __monsterTrack__ is true, 2 new sections of code are ran when  _onMonsterTarget_ is called. The __lastKnownPlayerTargets__ is updated with the current player and an overloaded _getClosestPlayer_ method is called. This overloaded method takes the player from __lastKnownPlayerTargets__  as a parameter. This methods first runs the original _getClosestPlayer_ and will return it if it finds a target. However, if it returns `null` this new overloaded method will return the last known player, causing the mob to re-target the player it just lost. As a fallback, if the monster lost the player last known player because they died or left the arena it will target a random alive player in the arena.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->

This commit adds a new per-arena setting `monster-tracks-player` that can be used to make monsters always follow a player. If monsters lose their target and can not find a closer one, they will follow their last known target. If their last known target dies or leaves the arena, they will follow a random target.
