### PR TITLE
Add configuration option for monster to glow after specified delay time.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ These changes will (most likely) be included in the next version.
 - Husks, drowned, piglins, hoglins, and zoglins can now be spawned in their baby versions using the `baby` prefix seen on other monster types (e.g. `baby-zombie`).
 - Pet names are now per-class configurable via the optional `pet-name` property, which defaults to `<display-name>'s pet` (the `<player-name>` variable is also supported).
 - New per-arena setting `auto-leave-on-end` can be used to automatically "kick" spectators when the current session ends.
+- New per-arena setting `monster-glow-delay` can be used to apply a glowing effect per-wave after a specified time making it easier to find monsters in the arena.
 - Added boss abilities `disorient-all`, `fetch-all`, `pull-all`, and `throw-all`. These abilities work like their target-specific and distance-based counterparts, but affect all players in the arena.
 - (API) MobArena's internal command handler now supports registering pre-instantiated subcommand instances. This should make it easier for extensions to avoid the Singleton anti-pattern for command dependencies.
 - (API) MobArena now fires MobArenaPreReloadEvent and MobArenaReloadEvent before and after, respectively, reloading its config-file. This should allow extensions and other plugins to better respond to configuration changes.

--- a/src/main/java/com/garbagemule/MobArena/MonsterManager.java
+++ b/src/main/java/com/garbagemule/MobArena/MonsterManager.java
@@ -19,6 +19,7 @@ import java.util.Set;
 public class MonsterManager
 {
     private Set<LivingEntity> monsters, sheep, golems;
+    private Map<Integer, Set<LivingEntity>> waveMonsters;
     private Map<LivingEntity,MABoss> bosses;
     private Map<LivingEntity,List<ItemStack>> suppliers;
     private Set<LivingEntity> mounts;
@@ -27,6 +28,7 @@ public class MonsterManager
 
     public MonsterManager() {
         this.monsters   = new HashSet<>();
+        this.waveMonsters = new HashMap<>();
         this.sheep      = new HashSet<>();
         this.golems     = new HashSet<>();
         this.bosses     = new HashMap<>();
@@ -38,6 +40,7 @@ public class MonsterManager
 
     public void reset() {
         monsters.clear();
+        waveMonsters.clear();
         sheep.clear();
         golems.clear();
         bosses.clear();
@@ -88,8 +91,23 @@ public class MonsterManager
         return monsters;
     }
 
+    public Set<LivingEntity> getWaveMonsters(int wave) {
+        return waveMonsters.get(wave);
+    }
+
     public void addMonster(LivingEntity e) {
         monsters.add(e);
+    }
+
+    public void addWaveMonster(LivingEntity e, int wave) {
+        if(waveMonsters.containsKey(wave)) {
+            waveMonsters.get(wave).add(e);
+        }
+        else {
+            Set<LivingEntity> set = new HashSet<>();
+            set.add(e);
+            waveMonsters.put(wave, set);
+        }
     }
 
     public boolean removeMonster(Entity e) {

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -22,6 +22,7 @@ max-players: 0
 max-join-distance: 0
 join-interrupt-timer: 0
 first-wave-delay: 5
+monster-glow-delay: 120
 next-wave-delay: 0
 wave-interval: 15
 final-wave: 0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* Adds a new per-arena setting `monster-glow-delay` that adds a glow effect to mobs after a set time.


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

Depending on the map design and how a configuration file is set up, often players can find themselves spending a long time searching for mobs in larger arenas. Some map makers do not want to sacrifice the layout of the arena entirely for the sake of pathing or are always able to remedy monsters getting stuck on certain obstacles. When monsters are spawned in arenas like this, sometimes they can be very difficult to locate.

* See for https://github.com/garbagemule/MobArena/issues/629 for details.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->

Added a HashMap **waveMonsters** to store monsters and ties them to the wave in which they were spawned. A BukkitRunnable **runnable** is created to run after the seconds defined in the **monsterGlowDelay** variable. This will apply a GLOWING potion effect using **PotionEffectParser**to any monster that is still alive from the wave for which the **runnable** task is called for. This method allows future use of modifying monsters on a per-wave basis and not every current living monster.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->

This commit adds a new per-arena setting `monster-glow-delay` that can be used to give monsters a glowing effect after a specified time.
