### PR TITLE
Added config option `keep-drops` which allows players to keep items t…

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/ArenaClass.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaClass.java
@@ -268,6 +268,9 @@ public class ArenaClass
             if (arena != null) {
                 try {
                     arena.getInventoryManager().equip(p);
+                    if (arena.isKeepDrops()) {
+                        arena.getInventoryManager().setOriginalItemsPDC(arena.getPlugin(), p);
+                    }
                     removeBannedItems(p.getInventory());
                 } catch (Exception e) {
                     am.getPlugin().getLogger().severe("Failed to give " + p.getName() + " their own items: " + e.getMessage());

--- a/src/main/java/com/garbagemule/MobArena/framework/Arena.java
+++ b/src/main/java/com/garbagemule/MobArena/framework/Arena.java
@@ -64,6 +64,8 @@ public interface Arena
 
     int getMaxPlayers();
 
+    boolean isKeepDrops();
+
     List<Thing> getEntryFee();
 
     Set<Map.Entry<Integer, ThingPicker>> getEveryWaveEntrySet();

--- a/src/main/java/com/garbagemule/MobArena/steps/CompositeStep.java
+++ b/src/main/java/com/garbagemule/MobArena/steps/CompositeStep.java
@@ -1,0 +1,34 @@
+package com.garbagemule.MobArena.steps;
+
+import org.bukkit.entity.Player;
+
+public class CompositeStep extends PlayerStep {
+
+    private final Step original;
+    private final Step next;
+
+
+    private CompositeStep(Player player, Step original, Step next) {
+        super(player);
+        this.original = original;
+        this.next = next;
+    }
+
+    @Override
+    public void run() {
+        this.original.run();
+        this.next.run();
+    }
+
+    @Override
+    public void undo() {
+        this.original.undo();
+        this.next.undo();
+    }
+
+
+    public static StepFactory create(Step original, Step next) {
+        return player -> new CompositeStep(player, original, next);
+    }
+
+}

--- a/src/main/java/com/garbagemule/MobArena/steps/KeepDropsStep.java
+++ b/src/main/java/com/garbagemule/MobArena/steps/KeepDropsStep.java
@@ -1,0 +1,71 @@
+package com.garbagemule.MobArena.steps;
+
+import com.garbagemule.MobArena.framework.Arena;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.logging.Level;
+
+public class KeepDropsStep extends PlayerStep {
+
+    private final File keepDrops;
+    private final Arena arena;
+
+    private ItemStack[] contents;
+    private File backup;
+
+    private KeepDropsStep(Player player, Arena arena) {
+        super(player);
+        this.keepDrops = new File(arena.getPlugin().getDataFolder(), "extra-drops");
+        this.arena = arena;
+    }
+
+    @Override
+    public void run() {
+        contents = player.getInventory().getContents();
+        createBackup();
+
+        player.getInventory().clear();
+    }
+
+    @Override
+    public void undo() {
+        for (ItemStack itemStack : contents) {
+            if (itemStack == null) continue;
+            player.getInventory().addItem(itemStack);
+        }
+
+        arena.getInventoryManager().removeKeepDrops(player);
+        deleteBackup();
+    }
+
+    private void createBackup() {
+        arena.getInventoryManager().removeOriginalItems(arena.getPlugin(), player);
+        YamlConfiguration yaml = new YamlConfiguration();
+        yaml.set("contents", contents);
+
+        backup = new File(keepDrops, player.getUniqueId().toString());
+        try {
+            yaml.save(backup);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store keep-drops for " + player.getName(), e);
+        }
+        arena.getInventoryManager().putKeepDrops(player, contents);
+    }
+
+    private void deleteBackup() {
+        try {
+            Files.delete(backup.toPath());
+        } catch (IOException e) {
+            arena.getPlugin().getLogger().log(Level.WARNING, "Couldn't delete backup inventory file for " + player.getName(), e);
+        }
+    }
+
+    public static StepFactory create(Arena arena) {
+        return player -> new KeepDropsStep(player, arena);
+    }
+}

--- a/src/main/java/com/garbagemule/MobArena/util/inventory/InventoryManager.java
+++ b/src/main/java/com/garbagemule/MobArena/util/inventory/InventoryManager.java
@@ -2,20 +2,27 @@ package com.garbagemule.MobArena.util.inventory;
 
 import com.garbagemule.MobArena.MobArena;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
 public class InventoryManager
 {
+    private static final String ORIGINAL_ITEM_KEY = "original-item";
+
     private Map<Player, ItemStack[]> inventories;
 
     public InventoryManager() {
@@ -32,6 +39,36 @@ public class InventoryManager
             return;
         }
         p.getInventory().setContents(contents);
+    }
+
+    /**
+     * Sets PDC on the player's items from when they first joined the arena
+     * So that item drops in the arena can be kept when they leave
+     */
+    public void setOriginalItemsPDC(MobArena plugin, Player player) {
+        final NamespacedKey key = new NamespacedKey(plugin, ORIGINAL_ITEM_KEY);
+        for (ItemStack itemStack : player.getInventory().getContents()) {
+            if (itemStack == null) continue;
+            final ItemMeta itemMeta = itemStack.getItemMeta();
+            if (itemMeta == null) continue;
+            itemMeta.getPersistentDataContainer().set(key, PersistentDataType.BYTE, (byte) 1);
+            itemStack.setItemMeta(itemMeta);
+        }
+    }
+
+    public void removeOriginalItems(MobArena plugin, Player player) {
+        final NamespacedKey key = new NamespacedKey(plugin, ORIGINAL_ITEM_KEY);
+        final ItemStack[] contents = player.getInventory().getContents();
+        for (int i = 0; i < contents.length; i++) {
+            final ItemStack itemStack = contents[i];
+            if (itemStack == null) continue;
+            final ItemMeta itemMeta = itemStack.getItemMeta();
+            if (itemMeta == null) continue;
+            if (itemMeta.getPersistentDataContainer().has(key, PersistentDataType.BYTE)) {
+                itemStack.setType(Material.AIR);
+                player.getInventory().clear(i);
+            }
+        }
     }
 
     public void remove(Player p) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,8 @@ author: garbagemule
 main: com.garbagemule.MobArena.MobArena
 version: '${project.version}'
 api-version: 1.13
-softdepend: [Multiverse-Core,Towny,Heroes,MagicSpells,Vault]
+softdepend: [Multiverse-Core,Towny,Heroes,MagicSpells,Vault,AdvancedEnchantments]
+loadbefore: [AdvancedEnchantments]
 commands:
     ma:
         description: Base command for MobArena

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -44,6 +44,7 @@ display-waves-as-level: false
 display-timer-as-level: false
 use-scoreboards: true
 isolated-chat: false
+keep-drops: false
 announcer-type: title
 global-join-announce: false
 global-end-announce: false


### PR DESCRIPTION
…hey find in the arena


# Summary

* This is a…
    * [ ] Bug fix
    * [X ] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

It adds the config option `keep-drops` which allows players to keep items from the arena after is is complete.

# Problem

It is just an extra feature that could be helpful for people who want mob drops or other items to be kept.

* GitHub issue (_optional_):
#750 

# Solution

I made it so that when the player joins the arena, PDC is set to all their items to identify them. Then, when the player leaves, the items with the PDC are removed from the inventory, and the rest of the items are stored. Then, after the player's inventory has been reset, the extra items are added back to their inventory.


# Action

It would be helpful if you could review it to make sure I didn't miss any areas where players' inventories are cleared and restored.
