### PR TITLE
New Feature: [re]join a running game

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 'Set up JDK'
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '16'
           distribution: 'adopt'
 
       - name: 'Cache dependencies'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# OS Files
+.DS_Store
+
+# IDE Files
+.vscode/
+
 # Java
 *.class
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,14 @@
 
   <build>
     <plugins>
-      <!-- Use Java 8 for compilation -->
+      <!-- Use Java 16 for compilation -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>16</source>
+          <target>16</target>
         </configuration>
       </plugin>
 
@@ -39,7 +39,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.5.0</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <minimizeJar>true</minimizeJar>

--- a/src/main/java/com/garbagemule/MobArena/ArenaClass.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaClass.java
@@ -174,8 +174,6 @@ public class ArenaClass
      * @param p a player
      */
     public void grantItems(Player p) {
-        PlayerInventory inv = p.getInventory();
-
         // Fork over the items.
         items.forEach(item -> item.giveTo(p));
 
@@ -294,8 +292,9 @@ public class ArenaClass
                 case ENDER_CHEST:
                 case SHULKER_SHELL:
                     return true;
+                default:
+                    return type.name().endsWith("SHULKER_BOX");
             }
-            return type.name().endsWith("SHULKER_BOX");
         }
     }
 }

--- a/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
@@ -88,7 +88,7 @@ public class ArenaImpl implements Arena
     private ConfigurationSection settings;
 
     // Run-time settings and critical config settings
-    private boolean enabled, protect, running, edit;
+    private boolean enabled, protect, running, edit, rejoin;
 
     // World stuff
     private boolean allowMonsters, allowAnimals;
@@ -166,6 +166,7 @@ public class ArenaImpl implements Arena
 
         this.enabled = settings.getBoolean("enabled", false);
         this.protect = settings.getBoolean("protect", true);
+        this.rejoin  = settings.getBoolean("rejoin", false);
         this.running = false;
         this.edit    = false;
 
@@ -488,7 +489,7 @@ public class ArenaImpl implements Arena
         announce(msg.toString());
     }
 
-    private boolean justAddReadyPlayers() {
+    private boolean addReadyPlayers() {
         for (Player p : readyPlayers) {
             lobbyPlayers.remove(p);
             arenaPlayers.add(p);
@@ -523,10 +524,15 @@ public class ArenaImpl implements Arena
                 price.takeFrom(p);
             }
 
+            monsterManager.getBossMonsters().forEach(entity -> {
+                MABoss boss = monsterManager.getBoss(entity);
+                if (boss != null) {
+                    boss.getHealthBar().addPlayer(p);
+                }
+            });
+
             scoreboard.removePlayer(p);
             scoreboard.addPlayer(p);
-
-            getMessenger().tell(p, "Maybe Rejoined?");
         }
 
         return true;
@@ -535,8 +541,8 @@ public class ArenaImpl implements Arena
     @Override
     public boolean startArena() {
         // Sanity-checks
-        if (running) {
-            return justAddReadyPlayers();
+        if (running && rejoin) {
+            return addReadyPlayers();
         }
 
         if (running || lobbyPlayers.isEmpty() || !readyPlayers.containsAll(lobbyPlayers)) {
@@ -1511,6 +1517,11 @@ public class ArenaImpl implements Arena
     }
 
     @Override
+    public boolean canRejoin() {
+        return rejoin;
+    }
+
+    @Override
     public String configName()
     {
         return name;
@@ -1630,10 +1641,8 @@ public class ArenaImpl implements Arena
             messenger.tell(p, Msg.JOIN_ARENA_EDIT_MODE);
         else if (arenaPlayers.contains(p) || lobbyPlayers.contains(p))
             messenger.tell(p, Msg.JOIN_ALREADY_PLAYING);
-        else if (running) {
-            return true;
-            //messenger.tell(p, Msg.JOIN_ARENA_IS_RUNNING);
-        }
+        else if (running && !rejoin)
+            messenger.tell(p, Msg.JOIN_ARENA_IS_RUNNING);
         else if (!hasPermission(p))
             messenger.tell(p, Msg.JOIN_ARENA_PERMISSION);
         else if (getMaxPlayers() > 0 && lobbyPlayers.size() >= getMaxPlayers())

--- a/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaImpl.java
@@ -1402,6 +1402,8 @@ public class ArenaImpl implements Arena
                     case PRIMED_TNT:
                     case SHULKER_BULLET:
                         e.remove();
+                    default:
+                        break;
                 }
             }
         }

--- a/src/main/java/com/garbagemule/MobArena/ArenaListener.java
+++ b/src/main/java/com/garbagemule/MobArena/ArenaListener.java
@@ -329,6 +329,8 @@ public class ArenaListener
             case SNOW:
                 event.setCancelled(true);
                 break;
+            default:
+                break;
         }
     }
 
@@ -353,6 +355,8 @@ public class ArenaListener
             case EXPLOSION:
             case LAVA:
                 event.setCancelled(true);
+                break;
+            default:
                 break;
         }
     }
@@ -410,6 +414,8 @@ public class ArenaListener
                 }
                 return;
             }
+            default:
+                break;
         }
 
         // If not custom, we probably don't want it, so get rid of it

--- a/src/main/java/com/garbagemule/MobArena/ScoreboardManager.java
+++ b/src/main/java/com/garbagemule/MobArena/ScoreboardManager.java
@@ -81,11 +81,6 @@ public class ScoreboardManager {
             return;
         }
 
-        String name = ChatColor.GRAY + player.getName();
-        if (name.length() > 16) {
-            name = name.substring(0, 15);
-        }
-
         Score score = kills.getScore(player.getName());
         if (score == null) {
             return;
@@ -94,18 +89,25 @@ public class ScoreboardManager {
         int value = score.getScore();
         scoreboard.resetScores(player.getName());
 
-        /* In case the player has no kills, they will not show up on the
-         * scoreboard unless they are first given a different score.
-         * If zero kills, the score is set to 8 (which looks a bit like
-         * 0), and then in the next tick, it's set to 0. Otherwise, the
-         * score is just set to its current value.
-         */
-        final Score fake = kills.getScore(name);
-        if (value == 0) {
-            fake.setScore(8);
-            arena.scheduleTask(() -> fake.setScore(0), 1);
-        } else {
-            fake.setScore(value);
+        if (!arena.canRejoin()) {
+            /* In case the player has no kills, they will not show up on the
+             * scoreboard unless they are first given a different score.
+             * If zero kills, the score is set to 8 (which looks a bit like
+             * 0), and then in the next tick, it's set to 0. Otherwise, the
+             * score is just set to its current value.
+             */
+            String name = ChatColor.GRAY + player.getName();
+            if (name.length() > 16) {
+                name = name.substring(0, 15);
+            }
+
+            final Score fake = kills.getScore(name);
+            if (value == 0) {
+                fake.setScore(8);
+                arena.scheduleTask(() -> fake.setScore(0), 1);
+            } else {
+                fake.setScore(value);
+            }
         }
     }
 

--- a/src/main/java/com/garbagemule/MobArena/commands/setup/AddArenaCommand.java
+++ b/src/main/java/com/garbagemule/MobArena/commands/setup/AddArenaCommand.java
@@ -10,9 +10,6 @@ import com.garbagemule.MobArena.util.Slugs;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 @CommandInfo(
     name    = "addarena",
     pattern = "(add|new)arena",

--- a/src/main/java/com/garbagemule/MobArena/commands/setup/SetupCommand.java
+++ b/src/main/java/com/garbagemule/MobArena/commands/setup/SetupCommand.java
@@ -328,8 +328,9 @@ public class SetupCommand implements Command, Listener {
             switch (action) {
                 case LEFT_CLICK_BLOCK:  regions(lower, loc); return true;
                 case RIGHT_CLICK_BLOCK: regions(upper, loc); return true;
+                default:
+                    return false;
             }
-            return false;
         }
 
         private boolean warps(PlayerInteractEvent event) {
@@ -350,8 +351,9 @@ public class SetupCommand implements Command, Listener {
                     }
                     next = formatYellow("Current warp: %s", warpArray[warpIndex]);
                     return true;
+                default:
+                    return false;
             }
-            return false;
         }
 
         private boolean spawns(PlayerInteractEvent event) {
@@ -364,8 +366,9 @@ public class SetupCommand implements Command, Listener {
             switch (event.getAction()) {
                 case LEFT_CLICK_BLOCK:  spawns(l, true);  return true;
                 case RIGHT_CLICK_BLOCK: spawns(l, false); return true;
+                default:
+                    return false;
             }
-            return false;
         }
 
         private boolean chests(PlayerInteractEvent event) {
@@ -377,8 +380,9 @@ public class SetupCommand implements Command, Listener {
             switch (event.getAction()) {
                 case LEFT_CLICK_BLOCK:  chests(b, true);  return true;
                 case RIGHT_CLICK_BLOCK: chests(b, false); return true;
+                default:
+                    return false;
             }
-            return false;
         }
 
         private void fix(Location loc) {

--- a/src/main/java/com/garbagemule/MobArena/formula/Environment.java
+++ b/src/main/java/com/garbagemule/MobArena/formula/Environment.java
@@ -128,7 +128,43 @@ class Environment {
         operators.add(i, token);
     }
 
-    @SuppressWarnings("Convert2MethodRef")
+    // math functions implemented here to get rid of "unchecked conversion" warnings...
+    private static Double sqrt(Double a) {
+        return Math.sqrt(a);
+    }
+
+    private static Double abs(Double a) {
+        return Math.abs(a);
+    }
+
+    private static Double ceil(Double a) {
+        return Math.ceil(a);
+    }
+
+    private static Double floor(Double a) {
+        return Math.floor(a);
+    }
+
+    private static Double sin(Double a) {
+        return Math.sin(a);
+    }
+
+    private static Double cos(Double a) {
+        return Math.cos(a);
+    }
+
+    private static Double tan(Double a) {
+        return Math.tan(a);
+    }
+
+    private static Double min(Double a, Double b) {
+        return Math.min(a, b);
+    }
+
+    private static Double max(Double a, Double b) {
+        return Math.max(a, b);
+    }
+
     static Environment createDefault() {
         Environment result = new Environment();
 
@@ -149,20 +185,20 @@ class Environment {
         result.registerBinaryOperator("^", 4, false, (a, b) -> Math.pow(a, b));
 
         // Unary functions
-        result.registerUnaryFunction("sqrt", Math::sqrt);
-        result.registerUnaryFunction("abs", Math::abs);
+        result.registerUnaryFunction("sqrt", Environment::sqrt);
+        result.registerUnaryFunction("abs", Environment::abs);
 
-        result.registerUnaryFunction("ceil", Math::ceil);
-        result.registerUnaryFunction("floor", Math::floor);
+        result.registerUnaryFunction("ceil", Environment::ceil);
+        result.registerUnaryFunction("floor", Environment::floor);
         result.registerUnaryFunction("round", value -> (double) Math.round(value));
 
-        result.registerUnaryFunction("sin", Math::sin);
-        result.registerUnaryFunction("cos", Math::cos);
-        result.registerUnaryFunction("tan", Math::tan);
+        result.registerUnaryFunction("sin", Environment::sin);
+        result.registerUnaryFunction("cos", Environment::cos);
+        result.registerUnaryFunction("tan", Environment::tan);
 
         // Binary functions
-        result.registerBinaryFunction("min", Math::min);
-        result.registerBinaryFunction("max", Math::max);
+        result.registerBinaryFunction("min", Environment::min);
+        result.registerBinaryFunction("max", Environment::max);
 
         return result;
     }

--- a/src/main/java/com/garbagemule/MobArena/formula/FormulaManager.java
+++ b/src/main/java/com/garbagemule/MobArena/formula/FormulaManager.java
@@ -20,32 +20,26 @@ public class FormulaManager {
         this.parser = parser;
     }
 
-    @SuppressWarnings("unused")
     public void registerConstant(String name, double value) {
         env.registerConstant(name, value);
     }
 
-    @SuppressWarnings("unused")
     public void registerVariable(String name, Formula formula) {
         env.registerVariable(name, formula);
     }
 
-    @SuppressWarnings("unused")
     public void registerUnaryOperator(String symbol, int precedence, UnaryOperation operation) {
         env.registerUnaryOperator(symbol, precedence, operation);
     }
 
-    @SuppressWarnings("unused")
     public void registerBinaryOperator(String symbol, int precedence, boolean left, BinaryOperation operation) {
         env.registerBinaryOperator(symbol, precedence, left, operation);
     }
 
-    @SuppressWarnings("unused")
     public void registerUnaryFunction(String name, UnaryOperation operation) {
         env.registerUnaryFunction(name, operation);
     }
 
-    @SuppressWarnings("unused")
     public void registerBinaryFunction(String name, BinaryOperation operation) {
         env.registerBinaryFunction(name, operation);
     }

--- a/src/main/java/com/garbagemule/MobArena/framework/Arena.java
+++ b/src/main/java/com/garbagemule/MobArena/framework/Arena.java
@@ -219,6 +219,8 @@ public interface Arena
 
     boolean isDead(Player p);
 
+    boolean canRejoin();
+
     String configName();
 
     /**

--- a/src/main/java/com/garbagemule/MobArena/leaderboards/Leaderboard.java
+++ b/src/main/java/com/garbagemule/MobArena/leaderboards/Leaderboard.java
@@ -266,6 +266,8 @@ public class Leaderboard
                 case SOUTH: return BlockFace.EAST;
                 case WEST: return BlockFace.SOUTH;
                 case EAST: return BlockFace.NORTH;
+                default:
+                    break;
             }
         }
         return null;

--- a/src/main/java/com/garbagemule/MobArena/region/ArenaRegion.java
+++ b/src/main/java/com/garbagemule/MobArena/region/ArenaRegion.java
@@ -524,8 +524,8 @@ public class ArenaRegion
         }
 
         // Set the coords and save
-        if (lower != null) setLocation(coords, r1.name().toLowerCase(), lower);
-        if (upper != null) setLocation(coords, r2.name().toLowerCase(), upper);
+        if (lower != null && r1 != null) setLocation(coords, r1.name().toLowerCase(), lower);
+        if (upper != null && r2 != null) setLocation(coords, r2.name().toLowerCase(), upper);
         save();
 
         // Reload regions and verify data

--- a/src/main/java/com/garbagemule/MobArena/util/EntityPosition.java
+++ b/src/main/java/com/garbagemule/MobArena/util/EntityPosition.java
@@ -9,7 +9,6 @@ import java.io.Serializable;
  * NOTE: I (garbagemule) DID NOT WRITE THIS CLASS (notice the author below)
  * @author creadri
  */
-@SuppressWarnings("serial")
 public class EntityPosition implements Serializable{
     private double x;
     private double y;

--- a/src/main/java/com/garbagemule/MobArena/util/config/ConfigUtils.java
+++ b/src/main/java/com/garbagemule/MobArena/util/config/ConfigUtils.java
@@ -16,6 +16,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Scanner;
 import java.util.Set;
 
@@ -46,11 +47,21 @@ public class ConfigUtils
             if (is == null) {
                 throw new IllegalStateException("Couldn't read " + res + " from jar, please re-install MobArena");
             }
-            Scanner scanner = new Scanner(is).useDelimiter("\\A");
-            if (!scanner.hasNext()) {
-                throw new IllegalStateException("No content in " + res + " in jar, please re-install MobArena");
+            String contents;
+            Scanner scanner = null;
+            try {
+                scanner = new Scanner(is).useDelimiter("\\A");
+                contents = scanner.next();
+            } catch (NoSuchElementException e) {
+                    throw new IllegalStateException("No content in " + res + " in jar, please re-install MobArena");
+            } catch (Exception e) {
+                throw e;
+            } finally {
+                if (scanner != null) {
+                    scanner.close();
+                }
             }
-            String contents = scanner.next();
+
             YamlConfiguration yaml = new YamlConfiguration();
             try {
                 yaml.loadFromString(contents);

--- a/src/main/java/com/garbagemule/MobArena/waves/MABoss.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/MABoss.java
@@ -1,7 +1,6 @@
 package com.garbagemule.MobArena.waves;
 
 import com.garbagemule.MobArena.healthbar.HealthBar;
-import com.garbagemule.MobArena.things.Thing;
 import com.garbagemule.MobArena.things.ThingPicker;
 import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;

--- a/src/main/java/com/garbagemule/MobArena/waves/WaveParser.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/WaveParser.java
@@ -98,6 +98,8 @@ public class WaveParser
             case BOSS:
                 result = parseBossWave(arena, name, config);
                 break;
+            default:
+                throw new ConfigError("Unknown wave type for wave " + name + " of arena " + arena.configName() + ": " + t);
         }
 
         // Grab the branch-specific nodes.

--- a/src/main/java/com/garbagemule/MobArena/waves/types/BossWave.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/types/BossWave.java
@@ -4,7 +4,6 @@ import com.garbagemule.MobArena.Msg;
 import com.garbagemule.MobArena.formula.Formula;
 import com.garbagemule.MobArena.formula.Formulas;
 import com.garbagemule.MobArena.framework.Arena;
-import com.garbagemule.MobArena.things.Thing;
 import com.garbagemule.MobArena.things.ThingPicker;
 import com.garbagemule.MobArena.waves.AbstractWave;
 import com.garbagemule.MobArena.waves.BossAbilityThread;

--- a/src/main/resources/res/settings.yml
+++ b/src/main/resources/res/settings.yml
@@ -48,3 +48,4 @@ announcer-type: title
 global-join-announce: false
 global-end-announce: false
 show-death-messages: true
+rejoin: false


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

I run some servers with MobArena for young children, and one of the most often voiced complaints is that once they die they have to wait until the game ends before they can rejoin.  There is already a issue tracking this request with some interesting discussion about the challenge.  I'm not sure whether this addresses the full set of challenges described there, but it works very well for our use case.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
 -->

* GitHub issue (_optional_): #664 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
 -->

When the `settings.rejoin` config file option is enabled (`true`), `startArena()` has been updated to run through the set of things it needs to do to add a player to the game, without doing all of the "start the arena" stuff.  That new code is self contained in a new function, `addReadyPlayers()` and is only called when the arena is already running (and the rejoin feature is enabled).

Additionally, the scoreboard ended up with duplicate entries for rejoined players (one greyed out and one not), so I've also updated the scoreboard logic to only do the "fake" weirdness (which I don't really understand) if rejoin is not enabled.  This seems to do the trick (except dead players that don't rejoin won't get greyed out, I guess). 

In `addReadyPlayers()`, I also needed to add the player to any active bosses healthbars, otherwise the healthbar wouldn't show up when they rejoined.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
 -->
Review & playtesting would be much appreciated.  I suspect based on the reading of #664 that there are likely to be interactions with other features which don't work correctly.  However, we haven't noticed any issues with the basic features we're using (pretty much a stock config).

You can find the build from the github action here:  https://github.com/tadhunt/MobArena/actions/runs/6132540696

I've only tested this PR in a branch that also contains #769 since all of my development and testing is on top of that, so if that PR doesn't get integrated, it's worth doing some more playtesting with just this PR to make sure there aren't any lingering issues.

