### PR TITLE
Added COMBO wave 🎉

### DIFF
--- a/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
+++ b/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
@@ -190,7 +190,10 @@ public class MASpawnThread implements Runnable
             handleWave(cw.getWaveA(), wave, true);
             handleWave(cw.getWaveB(), wave, true);
 
-            cw.getWaveA().announce(arena, wave); // announce only waveA in outermost COMBO wave.
+
+            if (!comboChild) {
+                cw.getWaveA().announce(arena, wave); // announce only waveA in outermost COMBO wave.
+            }
             return;
         }
 

--- a/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
+++ b/src/main/java/com/garbagemule/MobArena/MASpawnThread.java
@@ -15,6 +15,7 @@ import com.garbagemule.MobArena.waves.Wave;
 import com.garbagemule.MobArena.waves.WaveManager;
 import com.garbagemule.MobArena.waves.enums.WaveType;
 import com.garbagemule.MobArena.waves.types.BossWave;
+import com.garbagemule.MobArena.waves.types.ComboWave;
 import com.garbagemule.MobArena.waves.types.SupplyWave;
 import com.garbagemule.MobArena.waves.types.UpgradeWave;
 import org.bukkit.Bukkit;
@@ -180,8 +181,22 @@ public class MASpawnThread implements Runnable
 
     private void spawnWave(int wave) {
         Wave w = waveManager.next();
+        handleWave(w, wave, false);
+    }
 
-        w.announce(arena, wave);
+    private void handleWave(Wave w, int wave, boolean comboChild) {
+        if (w.getType() == WaveType.COMBO) {
+            ComboWave cw = (ComboWave) w;
+            handleWave(cw.getWaveA(), wave, true);
+            handleWave(cw.getWaveB(), wave, true);
+
+            cw.getWaveA().announce(arena, wave); // announce only waveA in outermost COMBO wave.
+            return;
+        }
+
+        if (!comboChild) {
+            w.announce(arena, wave);
+        }
 
         arena.getScoreboard().updateWave(wave);
 

--- a/src/main/java/com/garbagemule/MobArena/waves/WaveParser.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/WaveParser.java
@@ -15,12 +15,7 @@ import com.garbagemule.MobArena.waves.ability.Ability;
 import com.garbagemule.MobArena.waves.ability.AbilityManager;
 import com.garbagemule.MobArena.waves.enums.WaveBranch;
 import com.garbagemule.MobArena.waves.enums.WaveType;
-import com.garbagemule.MobArena.waves.types.BossWave;
-import com.garbagemule.MobArena.waves.types.DefaultWave;
-import com.garbagemule.MobArena.waves.types.SpecialWave;
-import com.garbagemule.MobArena.waves.types.SupplyWave;
-import com.garbagemule.MobArena.waves.types.SwarmWave;
-import com.garbagemule.MobArena.waves.types.UpgradeWave;
+import com.garbagemule.MobArena.waves.types.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
@@ -98,6 +93,9 @@ public class WaveParser
             case BOSS:
                 result = parseBossWave(arena, name, config);
                 break;
+            case COMBO:
+                result = parseComboWave(arena, name, config);
+                break;
         }
 
         // Grab the branch-specific nodes.
@@ -122,7 +120,7 @@ public class WaveParser
         // Potion effects
         List<PotionEffect> effects = getPotionEffects(arena, name, config);
 
-        // Recurrent must have priority + frequency, single must have firstWave
+        // Recurrent must have priority + frequency, single must have firstWave, combo doesn't need this
         if (branch == WaveBranch.RECURRENT) {
             if (priority <= 0) {
                 throw new ConfigError("Missing or invalid 'priority' node for recurrent wave " + name + " of arena " + arena.configName());
@@ -348,6 +346,21 @@ public class WaveParser
         result.setDrops(stacks);
 
         return result;
+    }
+
+    private static Wave parseComboWave(Arena arena, String name, ConfigurationSection config) {
+        ConfigurationSection waveAConfig = config.getConfigurationSection("waveA");
+        if (waveAConfig == null) {
+            throw new ConfigError("No waveA defined in wave " + name + " of arena " + arena.configName() + ".");
+        }
+        Wave waveA = parseWave(arena, name, waveAConfig, WaveBranch.COMBO);
+        ConfigurationSection waveBConfig = config.getConfigurationSection("waveB");
+        if (waveBConfig == null) {
+            throw new ConfigError("No waveB defined in wave " + name + " of arena " + arena.configName() + ".");
+        }
+        Wave waveB = parseWave(arena, name, waveBConfig, WaveBranch.COMBO);
+
+        return new ComboWave(waveA, waveB);
     }
 
     /**

--- a/src/main/java/com/garbagemule/MobArena/waves/enums/WaveBranch.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/enums/WaveBranch.java
@@ -19,6 +19,13 @@ public enum WaveBranch
             }
             return ((wave - w.getFirstWave()) % w.getFrequency() == 0);
         }
+    },
+
+    COMBO {
+        @Override
+        public boolean matches(int wave, Wave w) {
+            return false; // doesn't get used anyway on COMBO branch
+        }
     };
 
     public abstract boolean matches(int wave, Wave w);

--- a/src/main/java/com/garbagemule/MobArena/waves/enums/WaveType.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/enums/WaveType.java
@@ -45,6 +45,13 @@ public enum WaveType
         public void announce(Arena arena, int wave) {
             arena.announce(Msg.WAVE_UPGRADE, "" + wave);
         }
+    },
+
+    COMBO {
+        @Override
+        public void announce(Arena arena, int wave) {
+            // announce waveA in MASpawnThread.handleWave()
+        }
     };
 
     public abstract void announce(Arena arena, int wave);

--- a/src/main/java/com/garbagemule/MobArena/waves/types/ComboWave.java
+++ b/src/main/java/com/garbagemule/MobArena/waves/types/ComboWave.java
@@ -1,0 +1,61 @@
+package com.garbagemule.MobArena.waves.types;
+
+import com.garbagemule.MobArena.framework.Arena;
+import com.garbagemule.MobArena.waves.AbstractWave;
+import com.garbagemule.MobArena.waves.MACreature;
+import com.garbagemule.MobArena.waves.Wave;
+import com.garbagemule.MobArena.waves.WaveUtils;
+import com.garbagemule.MobArena.waves.enums.WaveType;
+import org.bukkit.Location;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ComboWave extends AbstractWave {
+
+    private final Wave waveA;
+    private final Wave waveB;
+
+    public ComboWave(Wave waveA, Wave waveB) {
+        this.waveA = waveA;
+        this.waveB = waveB;
+        this.setType(WaveType.COMBO);
+    }
+
+    public Wave getWaveA() {
+        return waveA;
+    }
+
+    public Wave getWaveB() {
+        return waveB;
+    }
+
+    @Override
+    public Map<MACreature, Integer> getMonstersToSpawn(int wave, int playerCount, Arena arena) {
+        Map<MACreature, Integer> monstersA = this.waveA.getMonstersToSpawn(wave, playerCount, arena);
+        Map<MACreature, Integer> monstersB = this.waveB.getMonstersToSpawn(wave, playerCount, arena);
+
+        Map<MACreature, Integer> monstersCombined = new HashMap<>();
+        monstersCombined.putAll(monstersA);
+        monstersCombined.putAll(monstersB);
+
+        return monstersCombined;
+    }
+
+    public List<Location> getSpawnpoints(Arena arena) {
+        List<Location> spawnpointsA = waveA.getSpawnpoints(arena);
+        List<Location> spawnpointsB = waveB.getSpawnpoints(arena);
+
+        List<Location> spawnpointsCombined = super.getSpawnpoints(arena);
+        spawnpointsCombined.addAll(spawnpointsA);
+        spawnpointsCombined.addAll(spawnpointsB);
+
+        return WaveUtils.getValidSpawnpoints(arena, spawnpointsCombined, arena.getPlayersInArena());
+    }
+
+    @Override
+    public Wave copy() {
+        return new ComboWave(getWaveA(), getWaveB());
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 5f8c06b877b9b89491a05248061b53ee2f60e199)

<!--
    Hello! Thanks for submitting a pull request to MobArena. We appreciate your
    time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
 -->

# Summary

<!--
    Update the checkbox for the type of contribution you are making. To choose
    an option, add an X to the box. For example, if it's a bug fix, do this:

    * [X] Bug fix
 -->

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Documentation
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:


# Problem

[Discord reference](https://discordapp.com/channels/363735561179103237/436983158416867341/1463706237957968058)


# Solution

I decided to make the COMBO wave

# Action

Example config:
```
combo1:
          type: combo
          priority: 1
          frequency: 1
          waveA:
            type: default
            monsters:
                zombies: 10
                skeletons: 10
                spiders: 10
                creepers: 10
                wolves: 10
          waveB:
            type: combo
            waveA:
                type: swarm
                monster: slime
                amount: low
            waveB:
                type: upgrade
                upgrades:
                    all: potion:instant_heal:1
                    Archer: arrow:64
                    Oddjob: tnt:2, netherrack
```

The first waveA of a COMBO wave gets announced, that means in this case only the default wave would get announced.

